### PR TITLE
Disable SSL verification

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -64,6 +64,26 @@ class Client
     }
 
     /**
+     * Gets the value of the SSL verification flag.
+     *
+     * @return bool Returns true when SSL verification is enabled; false otherwise.
+     */
+    public function getSSLVerificationEnabled()
+    {
+        return $this->HttpClient->getSSLVerificationEnabled();
+    }
+
+    /**
+     * Sets the SSL verification flag to either true or false.
+     *
+     * @param bool $sslVerificationEnabled A value to enable or disable the setting.
+     */
+    public function setSSLVerificationEnabled($sslVerificationEnabled)
+    {
+        $this->HttpClient->setSSLVerificationEnabled($sslVerificationEnabled);
+    }
+
+    /**
      * @param $accessKey
      */
     public function setAccessKey ($accessKey)

--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -34,11 +34,20 @@ class HttpClient
     protected $Authentication;
 
     /**
+     * A flag that indicates whether or not SSL verification should take place.
+     * Always set this flag to true for production environments.
+     *
+     * @var bool
+     */
+    protected $sslVerificationEnabled;
+
+    /**
      * @param $endpoint
      */
     public function __construct($endpoint)
     {
         $this->endpoint = $endpoint;
+        $this->sslVerificationEnabled = true;
     }
 
     /**
@@ -55,6 +64,26 @@ class HttpClient
     public function setAuthentication(Common\Authentication $Authentication)
     {
         $this->Authentication = $Authentication;
+    }
+
+    /**
+     * Gets the value of the SSL verification flag.
+     *
+     * @return bool Returns true when SSL verification is enabled; false otherwise.
+     */
+    public function getSSLVerificationEnabled()
+    {
+        return $this->sslVerificationEnabled;
+    }
+
+    /**
+     * Sets the SSL verification flag to either true or false.
+     *
+     * @param bool $sslVerificationEnabled A value to enable or disable the setting.
+     */
+    public function setSSLVerificationEnabled($sslVerificationEnabled)
+    {
+        $this->sslVerificationEnabled = $sslVerificationEnabled;
     }
 
     /**
@@ -103,6 +132,11 @@ class HttpClient
         curl_setopt($curl, CURLOPT_URL, $this->getRequestUrl($resourceName, $query));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+
+        if (!$this->getSSLVerificationEnabled()) {
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+            curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+        }
 
         if ($method === self::REQUEST_GET) {
             curl_setopt($curl, CURLOPT_HTTPGET, true);


### PR DESCRIPTION
Made it possible to disable SSL verification. This should never be used in production environments but it makes developing a lot easier when no certificates are installed (e.g. a local installation).

I did not make the HTTP client publicly available with a getter since it's not available right now either. Instead I introduced two methods in the client which are directed to the HTTP client itself.

When the SSL verification flag is not set, PHP's default behavior is used.