### PR TITLE
Fix long user agent issue

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -52,6 +52,7 @@ class Client
     {
         $this->HttpClient = new Common\HttpClient(self::ENDPOINT);
         $this->HttpClient->addUserAgentString('MessageBird/ApiClient/' . self::CLIENT_VERSION);
+        $this->HttpClient->addUserAgentString($this->getPhpVersion());
 
         if ($accessKey !== null) {
             $this->setAccessKey($accessKey);
@@ -70,6 +71,15 @@ class Client
     {
         $Authentication = new Common\Authentication($accessKey);
         $this->HttpClient->setAuthentication($Authentication);
+    }
+
+    private function getPhpVersion()
+    {
+        if (!defined('PHP_VERSION_ID')) {
+            $version = explode('.', PHP_VERSION);
+            define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+        }
+        return "PHP/" . PHP_VERSION_ID;
     }
 
 }

--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -88,8 +88,6 @@ class HttpClient
     {
         $curl = curl_init();
 
-        $this->addUserAgentString('PHP/' . PHP_VERSION_ID);
-
         $headers = array (
             'User-agent: ' . implode(' ', $this->userAgent),
             'Accepts: application/json',


### PR DESCRIPTION
When using this client in a long running PHP script (a background worker for example), the following line of code results in extremely long user agents:

https://github.com/messagebird/php-rest-api/blob/master/src/MessageBird/Common/HttpClient.php#L47

Example
```
MessageBird/ApiClient/1.1.2 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310 PHP/50310
```

As an added bonus this pull request makes sure that the PHP version is also included for PHP version below 5.2.7 (see http://php.net/phpversion#example-536)