### PR TITLE
CURLOPT_CONNECTTIMEOUT option is set in HttpClient now to 2 seconds

### DIFF
--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -101,6 +101,7 @@ class HttpClient
         curl_setopt($curl, CURLOPT_URL, $this->getRequestUrl($resourceName, $query));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 2);
 
         if ($method === self::REQUEST_GET) {
             curl_setopt($curl, CURLOPT_HTTPGET, true);


### PR DESCRIPTION
In order to avoid connect timeout problem while calling MessageBird API via CURL, I've adjusted the setting of CURLOPT_CONNECTTIMEOUT to 2 seconds.
