### PR TITLE
Fixed imperfection: GET functions were not encoded into the URL

### DIFF
--- a/src/MessageBird/Objects/Message.php
+++ b/src/MessageBird/Objects/Message.php
@@ -183,6 +183,17 @@ class Message extends Base
     }
 
     /**
+     * Get the CreationDatetime (as a pass by value enforced through the string concatination)
+     * 
+     * @return string
+     * @author Lawri van Buël
+     */
+    public function getCreationDatetime()
+    {
+        return $this->createdDatetime . "";
+    }    
+
+    /**
      * @param $object
      *
      * @return $this|void

--- a/src/MessageBird/Resources/Base.php
+++ b/src/MessageBird/Resources/Base.php
@@ -84,10 +84,39 @@ class Base
         return $this->processRequest($body);
     }
 
-
+    /**
+     * Add the parameters to the resourceName for use in a GET request.
+     * @author Lawri van Buël
+     * @param array $parameters
+     * @return string
+     */
+    private function prepGetParameters(array $parameters) {
+        $getOptions = "";
+        foreach ($parameters as $key => $value) {
+            $getOptions.="&$key=$value";
+        }
+        if(strlen($getOptions)>1){
+            $getOptions="?".substr($getOptions,1,strlen($getOptions));
+        }
+        else {
+            $getOptions = "";
+        }
+        return $this->resourceName.$getOptions;
+    }
+    
+    /**
+     * Modified by @author to make the get request include the parameters.
+     * get modification is done through a helper function.
+     * @author Lawri van Buël
+     * @param array $parameters
+     * @return Objects\BaseList|Base
+     * @throws Exceptions\HttpException
+     * @throws Exceptions\RequestException
+     * @throws Exceptions\ServerException
+     */
     public function getList($parameters = array ())
     {
-        list($status, , $body) = $this->HttpClient->performHttpRequest(Common\HttpClient::REQUEST_GET, $this->resourceName, $parameters);
+        list($status, , $body) = $this->HttpClient->performHttpRequest(Common\HttpClient::REQUEST_GET, $this->prepGetParameters($parameters), $parameters);
 
         if ($status === 200) {
             $body = json_decode($body);


### PR DESCRIPTION
This improvement fixes the following:
 [x] The Get parameters where encoded into the URL but send to the CURL library as POST options (and promptly disregarded when sending it to the server)

 This improvement encodes, as part of the URL, the GET parameters send to the server (the place they should be after-all ;) ) and it enables the correct functioning of GET calls like the ones for getting a paged List of messages.

It is not fully what I would want it to be, but it works.

----
Lawri van Buël - 040Lab B.V. 