### PR TITLE
Add curl extension to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-curl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.7.*"

--- a/src/MessageBird/Resources/Lookup.php
+++ b/src/MessageBird/Resources/Lookup.php
@@ -26,7 +26,8 @@ class Lookup extends Base
     }
 
     /**
-     * @param $phoneNumber
+     * @param string|int $phoneNumber
+     * @param string     $countryCode
      *
      * @return $this->Object
      *
@@ -39,7 +40,7 @@ class Lookup extends Base
         if(empty($phoneNumber)) {
             throw new InvalidArgumentException('The phone number cannot be empty.');
         }
-        $query = null; 
+        $query = null;
         if ($countryCode != null) {
             $query = array("countryCode" => $countryCode);
         }

--- a/src/MessageBird/Resources/LookupHlr.php
+++ b/src/MessageBird/Resources/LookupHlr.php
@@ -19,14 +19,15 @@ class LookupHlr extends Base
      */
     public function __construct(Common\HttpClient $HttpClient)
     {
-        $this->setObject(new Objects\HLR);
+        $this->setObject(new Objects\Hlr);
         $this->setResourceName('lookup');
 
         parent::__construct($HttpClient);
     }
 
     /**
-     * @param $phoneNumber
+     * @param Objects\Hlr $hlr
+     * @param string|null $countryCode
      *
      * @return $this->Object
      *
@@ -51,6 +52,7 @@ class LookupHlr extends Base
 
     /**
      * @param $phoneNumber
+     * @param string|null  $countryCode
      *
      * @return $this->Object
      *

--- a/tests/integration/BaseTest.php
+++ b/tests/integration/BaseTest.php
@@ -19,6 +19,6 @@ class BaseTest extends PHPUnit_Framework_TestCase
     public function testHttpClientMock()
     {
         $this->mockClient->expects($this->atLeastOnce())->method('addUserAgentString');
-        $client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
+        new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 }

--- a/tests/integration/balance/BalanceTest.php
+++ b/tests/integration/balance/BalanceTest.php
@@ -3,7 +3,7 @@ class BalanceTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
@@ -13,6 +13,6 @@ class BalanceTest extends BaseTest
     public function testReadBalance()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'balance', null, null);
-        $Hlr = $this->client->balance->read();
+        $this->client->balance->read();
     }
 }

--- a/tests/integration/hlr/HlrTest.php
+++ b/tests/integration/hlr/HlrTest.php
@@ -3,7 +3,7 @@ class HlrTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
@@ -27,6 +27,6 @@ class HlrTest extends BaseTest
     public function testReadHlr()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'hlr/message_id', null, null);
-        $Hlr = $this->client->hlr->read("message_id");
+        $this->client->hlr->read("message_id");
     }
 }

--- a/tests/integration/lookup/LookupTest.php
+++ b/tests/integration/lookup/LookupTest.php
@@ -3,7 +3,7 @@ class LookupTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 

--- a/tests/integration/messages/MessagesTest.php
+++ b/tests/integration/messages/MessagesTest.php
@@ -3,7 +3,7 @@ class MessageTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
@@ -100,7 +100,7 @@ class MessageTest extends BaseTest
     public function testListMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages', array ('offset' => 100, 'limit' => 30), null);
-        $MessageList = $this->client->messages->getList(array ('offset' => 100, 'limit' => 30));
+        $this->client->messages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     /**
@@ -109,7 +109,7 @@ class MessageTest extends BaseTest
     public function testReadMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages/message_id', null, null);
-        $MessageList = $this->client->messages->read("message_id");
+        $this->client->messages->read("message_id");
     }
 
     /**
@@ -118,6 +118,6 @@ class MessageTest extends BaseTest
     public function testDeleteMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'messages/message_id', null, null);
-        $MessageList = $this->client->messages->delete("message_id");
+        $this->client->messages->delete("message_id");
     }
 }

--- a/tests/integration/verify/VerifyTest.php
+++ b/tests/integration/verify/VerifyTest.php
@@ -3,7 +3,7 @@ class VerifyTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 

--- a/tests/integration/voicemessages/VoiceMessagesTest.php
+++ b/tests/integration/voicemessages/VoiceMessagesTest.php
@@ -3,7 +3,7 @@ class VoiceMessagesTest extends BaseTest
 {
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
@@ -28,7 +28,7 @@ class VoiceMessagesTest extends BaseTest
     public function testListMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages', array ('offset' => 100, 'limit' => 30), null);
-        $MessageList = $this->client->voicemessages->getList(array ('offset' => 100, 'limit' => 30));
+        $this->client->voicemessages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     /**
@@ -37,7 +37,7 @@ class VoiceMessagesTest extends BaseTest
     public function testReadMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages/message_id', null, null);
-        $MessageList = $this->client->voicemessages->read("message_id");
+        $this->client->voicemessages->read("message_id");
     }
 
     /**
@@ -46,6 +46,6 @@ class VoiceMessagesTest extends BaseTest
     public function testDeleteMessage()
     {
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'voicemessages/message_id', null, null);
-        $MessageList = $this->client->voicemessages->delete("message_id");
+        $this->client->voicemessages->delete("message_id");
     }
 }


### PR DESCRIPTION
The `curl` extension is not installed by default (on the popular platforms).
Please add it as a requirement to `composer`.

All other changes are typo fixes and PHPDoc corrections.