### PR TITLE
Bugfix to prevent calling the API without an Authentication

### DIFF
--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -75,11 +75,11 @@ class HttpClient
     }
 
     /**
-     * @param $string
+     * @param string $userAgent
      */
-    public function addUserAgentString($string)
+    public function addUserAgentString($userAgent)
     {
-        $this->userAgent[] = $string;
+        $this->userAgent[] = $userAgent;
     }
 
     /**
@@ -116,11 +116,17 @@ class HttpClient
      * @param string|null $body
      *
      * @return array
+     *
+     * @throws Exceptions\AuthenticateException
      * @throws Exceptions\HttpException
      */
     public function performHttpRequest($method, $resourceName, $query = null, $body = null)
     {
         $curl = curl_init();
+
+        if ($this->Authentication === null) {
+            throw new Exceptions\AuthenticateException('Can not perform API Request without Authentication');
+        }
 
         $headers = array (
             'User-agent: ' . implode(' ', $this->userAgent),

--- a/tests/integration/HttpClientTest.php
+++ b/tests/integration/HttpClientTest.php
@@ -32,4 +32,17 @@ class HttpClientTest extends PHPUnit_Framework_TestCase
     {
         new HttpClient(Client::ENDPOINT, 10, new \stdClass());
     }
+
+    /**
+     * Test that requests can only be made when there is an Authentication set
+     *
+     * @test
+     * @expectedException \MessageBird\Exceptions\AuthenticateException
+     * @expectedExceptionMessageRegExp #Can not perform API Request without Authentication#
+     */
+    public function testHttpClientWithoutAuthenticationException()
+    {
+        $client = new HttpClient(Client::ENDPOINT);
+        $client->performHttpRequest('foo', 'bar');
+    }
 }


### PR DESCRIPTION
By coincidence I found out that calling the API with null as accessKey leads to an "Trying to get property of non-object" error.
As the constructor of the MessageBird Client allows null as accessKey this should be caught later on.