### PR TITLE
Update verification example

### DIFF
--- a/examples/verify-verification.php
+++ b/examples/verify-verification.php
@@ -11,7 +11,7 @@ try {
     // Check if $VerifyResult->getStatus() === MessageBird\Objects\Verify::STATUS_VERIFIED
 
 } catch (\MessageBird\Exceptions\RequestException $e) {
-    // token was incorrect
+    echo 'token incorrect';
 } catch (\MessageBird\Exceptions\AuthenticateException $e) {
     // That means that your accessKey is unknown
     echo 'wrong login';

--- a/examples/verify-verification.php
+++ b/examples/verify-verification.php
@@ -10,6 +10,8 @@ try {
 
     // Check if $VerifyResult->getStatus() === MessageBird\Objects\Verify::STATUS_VERIFIED
 
+} catch (\MessageBird\Exceptions\RequestException $e) {
+    // token was incorrect
 } catch (\MessageBird\Exceptions\AuthenticateException $e) {
     // That means that your accessKey is unknown
     echo 'wrong login';


### PR DESCRIPTION
When token was incorrect, the REST API returns a non-2xx status code and that triggers an exception