### PR TITLE
Fix optional type details

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -12,7 +12,7 @@ class Client
     const ENDPOINT = 'https://rest.messagebird.com';
     const CHATAPI_ENDPOINT = 'https://chat.messagebird.com/1';
 
-    const CLIENT_VERSION = '1.6.3';
+    const CLIENT_VERSION = '1.6.4';
 
     /**
      * @var string

--- a/src/MessageBird/Objects/Message.php
+++ b/src/MessageBird/Objects/Message.php
@@ -138,13 +138,19 @@ class Message extends Base
      * @param $keyword
      * @param $tariff
      * @param $mid
+     * @param $member
      */
-    public function setPremiumSms($shortcode, $keyword, $tariff, $mid)
+    public function setPremiumSms($shortcode, $keyword, $tariff, $mid = null, $member = null)
     {
         $this->typeDetails['shortcode'] = $shortcode;
         $this->typeDetails['keyword']   = $keyword;
         $this->typeDetails['tariff']    = $tariff;
-        $this->typeDetails['mid']       = $mid;
+        if ($mid != null) {
+            $this->typeDetails['mid'] = $mid;
+        }
+        if ($member != null) {
+            $this->typeDetails['member'] = $member;
+        }
 
         $this->type = self::TYPE_PREMIUM;
     }


### PR DESCRIPTION
Conform https://developers.messagebird.com/docs/messaging, the `mid` parameter of `\MessageBird\Objects\Message::setPremiumSms` should be optional. Also, this PR adds the optional `member` option to this function for the `typeDetails` array of a message. 