### PR TITLE
Add `limit` property to `\MessageBird\Objects\BaseList`

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -13,7 +13,7 @@ class Client
     const CHATAPI_ENDPOINT = 'https://chat.messagebird.com/1';
     const VOICEAPI_ENDPOINT = 'https://voice.messagebird.com';
 
-    const CLIENT_VERSION = '1.9.2';
+    const CLIENT_VERSION = '1.9.3';
 
     /**
      * @var string

--- a/src/MessageBird/Objects/BaseList.php
+++ b/src/MessageBird/Objects/BaseList.php
@@ -10,6 +10,7 @@ namespace MessageBird\Objects;
 class BaseList extends Base
 {
 
+    public $limit;
     public $offset;
     public $count;
     public $totalCount;

--- a/tests/integration/contacts/ContactTest.php
+++ b/tests/integration/contacts/ContactTest.php
@@ -87,6 +87,7 @@ class ContactTest extends BaseTest
         $ResultingGroupList = $this->client->contacts->getGroups("contact_id");
 
         $GroupList = new \MessageBird\Objects\BaseList();
+        $GroupList->limit = 20;
         $GroupList->offset = 0;
         $GroupList->count = 1;
         $GroupList->totalCount = 1;


### PR DESCRIPTION
Without this, it's not possible to access the returned `limit` value of
a list response from the API.