### PR TITLE
Add the ability to add additional HTTP options to the HttpClient [#48]

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -212,4 +212,10 @@ class Client
 
         return 'PHP/' . PHP_VERSION_ID;
     }
+
+    public function addHttpOption($key, $value) {
+        $this->ChatAPIHttpClient->addHttpOption($key, $value);
+        $this->HttpClient->addHttpOption($key, $value);
+        $this->VoiceAPIHttpClient->addHttpOption($key, $value);
+    }
 }

--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -50,6 +50,12 @@ class HttpClient
      */
     private $headers = array();
 
+
+    /**
+     * @var array
+     */
+    private $httpOptions = array();
+
     /**
      * @param string $endpoint
      * @param int    $timeout           > 0
@@ -123,6 +129,15 @@ class HttpClient
         $this->headers = $headers;
     }
 
+
+    public function addHttpOption($key, $value) {
+        $this->httpOptions[$key] = $value;
+    }
+
+    public function getHttpOption( $key) {
+        return isset($this->httpOptions[$key]) ? $this->httpOptions[$key] : null;
+    }
+
     /**
      * @param string      $method
      * @param string      $resourceName
@@ -158,6 +173,10 @@ class HttpClient
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
+
+        foreach( $this->httpOptions as $key=>$value) {
+            curl_setopt($curl, $key, $value);
+        }
 
         if ($method === self::REQUEST_GET) {
             curl_setopt($curl, CURLOPT_HTTPGET, true);

--- a/tests/integration/HttpClientTest.php
+++ b/tests/integration/HttpClientTest.php
@@ -60,4 +60,19 @@ class HttpClientTest extends PHPUnit_Framework_TestCase
         $client = new HttpClient(Client::ENDPOINT);
         $client->performHttpRequest('foo', 'bar');
     }
+
+    /**
+     * Test that it allows additional CURL options 
+     */
+     public function testHttpClientWithHttpOptions() 
+     {
+        $client = new HttpClient(Client::ENDPOINT);
+        $url = "127.0.0.1:8080";
+
+        $client->addHttpOption(CURLOPT_PROXY, $url);
+
+        $this->assertSame($client->getHttpOption(CURLOPT_PROXY), $url);
+
+     }
+     
 }


### PR DESCRIPTION
This PR enables the HttpClient to receive additional parameters for CURL. This can be used to add the option to use the client behind the proxy or any other specific parameters for CURL.