### PR TITLE
Bump version to 1.13.0.

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -13,7 +13,7 @@ class Client
     const CHATAPI_ENDPOINT = 'https://chat.messagebird.com/1';
     const VOICEAPI_ENDPOINT = 'https://voice.messagebird.com';
 
-    const CLIENT_VERSION = '1.10.0';
+    const CLIENT_VERSION = '1.13.0';
 
     /**
      * @var string


### PR DESCRIPTION
Going from minor 10 to 13 because 11 and 12 were beta releases that
have been (temporarily) reverted in order to unblock new stable releases