### PR TITLE
Signedrequest notices

### DIFF
--- a/examples/signedrequest-verification.php
+++ b/examples/signedrequest-verification.php
@@ -6,7 +6,12 @@ require_once(__DIR__.'/../autoload.php');
 $requestValidator = new \MessageBird\RequestValidator('YOUR_SIGNING_KEY');
 
 // Set up the signed request from the PHP global variables.
-$request = \MessageBird\Objects\SignedRequest::createFromGlobals();
+try {
+    $request = \MessageBird\Objects\SignedRequest::createFromGlobals();
+} catch (\MessageBird\Exceptions\ValidationException $e) {
+    // The request was missing expected values, so respond accordingly.
+    http_response_code(412);
+}
 
 if (!$requestValidator->verify($request)) {
     // The request was invalid, so respond accordingly.

--- a/src/MessageBird/Objects/SignedRequest.php
+++ b/src/MessageBird/Objects/SignedRequest.php
@@ -51,8 +51,10 @@ class SignedRequest extends Base
     {
         $body = file_get_contents('php://input');
         $queryParameters = $_GET;
-        $requestTimestamp = $_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP'];
-        $signature = $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE'];
+        $requestTimestamp = isset($_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP']) ?
+            $_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP'] : null;
+        $signature = isset($_SERVER['HTTP_MESSAGEBIRD_SIGNATURE']) ?
+            $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE'] : null;
 
         $signedRequest = new SignedRequest();
         $signedRequest->loadFromArray(compact('body', 'queryParameters', 'requestTimestamp', 'signature'));

--- a/tests/unit/SignedRequestTest.php
+++ b/tests/unit/SignedRequestTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use MessageBird\Objects\SignedRequest;
+
+class SignedRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $query = array(
+            'recipient'      => '31612345678',
+            'reference'      => 'FOO',
+            'statusDatetime' => '2019-01-11T09:17:11+00:00',
+            'id'             => 'eef0ab57a9e049be946f3821568c2b2e',
+            'status'         => 'delivered',
+            'mccmnc'         => '20408',
+            'ported'         => '1',
+        );
+        $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
+        $requestTimestamp = 1547198231;
+        $body = '{"foo":"bar"}';
+
+        $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
+
+        self::assertEquals($requestTimestamp, $request->requestTimestamp);
+        self::assertEquals($body, $request->body);
+        self::assertEquals($query, $request->queryParameters);
+        self::assertEquals($signature, $request->signature);
+    }
+
+    public function testLoadFromArray()
+    {
+        $query = array(
+            'recipient' => '31612345678',
+            'reference' => 'FOO',
+            'statusDatetime' => '2019-01-11T09:17:11+00:00',
+            'id' => 'eef0ab57a9e049be946f3821568c2b2e',
+            'status' => 'delivered',
+            'mccmnc' => '20408',
+            'ported' => '1',
+        );
+        $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
+        $requestTimestamp = 1547198231;
+        $body = '{"foo":"bar"}';
+
+        $request = new SignedRequest();
+        $request->loadFromArray(array(
+            'queryParameters' => $query,
+            'signature' => $signature,
+            'requestTimestamp' => $requestTimestamp,
+            'body' => $body
+        ));
+
+        self::assertEquals($requestTimestamp, $request->requestTimestamp);
+        self::assertEquals($body, $request->body);
+        self::assertEquals($query, $request->queryParameters);
+        self::assertEquals($signature, $request->signature);
+    }
+
+    /**
+     * @expectedException \MessageBird\Exceptions\ValidationException
+     * @expectedExceptionMessage query
+     */
+    public function testLoadInvalidQuery()
+    {
+        $query = null;
+        $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
+        $requestTimestamp = 1547198231;
+        $body = '{"foo":"bar"}';
+
+        $request = new SignedRequest();
+        $request->loadFromArray(array(
+            'queryParameters' => $query,
+            'signature' => $signature,
+            'requestTimestamp' => $requestTimestamp,
+            'body' => $body
+        ));
+    }
+
+    /**
+     * @expectedException \MessageBird\Exceptions\ValidationException
+     * @expectedExceptionMessage signature
+     */
+    public function testLoadInvalidSignature()
+    {
+        $query = array(
+            'recipient'      => '31612345678',
+            'reference'      => 'FOO',
+            'statusDatetime' => '2019-01-11T09:17:11+00:00',
+            'id'             => 'eef0ab57a9e049be946f3821568c2b2e',
+            'status'         => 'delivered',
+            'mccmnc'         => '20408',
+            'ported'         => '1',
+        );
+        $signature = null;
+        $requestTimestamp = 1547198231;
+        $body = '{"foo":"bar"}';
+
+        $request = new SignedRequest();
+        $request->loadFromArray(array(
+            'queryParameters' => $query,
+            'signature' => $signature,
+            'requestTimestamp' => $requestTimestamp,
+            'body' => $body
+        ));
+    }
+
+    /**
+     * @expectedException \MessageBird\Exceptions\ValidationException
+     * @expectedExceptionMessage requestTimestamp
+     */
+    public function testLoadInvalidTimestamp()
+    {
+        $query = array(
+            'recipient'      => '31612345678',
+            'reference'      => 'FOO',
+            'statusDatetime' => '2019-01-11T09:17:11+00:00',
+            'id'             => 'eef0ab57a9e049be946f3821568c2b2e',
+            'status'         => 'delivered',
+            'mccmnc'         => '20408',
+            'ported'         => '1',
+        );
+        $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
+        $requestTimestamp = null;
+        $body = '{"foo":"bar"}';
+
+        $request = new SignedRequest();
+        $request->loadFromArray(array(
+            'queryParameters' => $query,
+            'signature' => $signature,
+            'requestTimestamp' => $requestTimestamp,
+            'body' => $body
+        ));
+    }
+
+    /**
+     * @expectedException \MessageBird\Exceptions\ValidationException
+     * @expectedExceptionMessage body
+     */
+    public function testLoadInvalidBody()
+    {
+        $query = array(
+            'recipient'      => '31612345678',
+            'reference'      => 'FOO',
+            'statusDatetime' => '2019-01-11T09:17:11+00:00',
+            'id'             => 'eef0ab57a9e049be946f3821568c2b2e',
+            'status'         => 'delivered',
+            'mccmnc'         => '20408',
+            'ported'         => '1',
+        );
+        $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
+        $requestTimestamp = 1547198231;
+        $body = null;
+
+        $request = new SignedRequest();
+        $request->loadFromArray(array(
+            'queryParameters' => $query,
+            'signature' => $signature,
+            'requestTimestamp' => $requestTimestamp,
+            'body' => $body
+        ));
+    }
+}


### PR DESCRIPTION
If expected header values are not set when using `SignedRequest::createFromGlobals()`, PHP Notices are issued, which may get in the way of normal operation (eg. returning other headers).

Update the method so that it checks for existence before access, and update the code example to show that `ValidationException`s can be thrown if these values are missing.