### PR TITLE
SignedRequest request timestamp value must be an int

### DIFF
--- a/src/MessageBird/Objects/SignedRequest.php
+++ b/src/MessageBird/Objects/SignedRequest.php
@@ -52,7 +52,7 @@ class SignedRequest extends Base
         $body = file_get_contents('php://input');
         $queryParameters = $_GET;
         $requestTimestamp = isset($_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP']) ?
-            $_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP'] : null;
+            (int)$_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP'] : null;
         $signature = isset($_SERVER['HTTP_MESSAGEBIRD_SIGNATURE']) ?
             $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE'] : null;
 


### PR DESCRIPTION
The value from `$_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP']` is a numeric string, but an `int` is expected by the validation in `SignedRequest::loadFromArray()`

Fixes #87