### PR TITLE
Be more precise in recognising three-part curl response

### DIFF
--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -219,7 +219,8 @@ class HttpClient
 
         // Split the header and body
         $parts = explode("\r\n\r\n", $response, 3);
-        list($responseHeader, $responseBody) = (strpos($parts[0], "\n") == false && strpos($parts[0], 'HTTP/1.') == 0) ? array ($parts[1], $parts[2]) : array ($parts[0], $parts[1]);
+        $isThreePartResponse = (strpos($parts[0], "\n") === false && strpos($parts[0], 'HTTP/1.') === 0);
+        list($responseHeader, $responseBody) = $isThreePartResponse ? array ($parts[1], $parts[2]) : array ($parts[0], $parts[1]);
 
         curl_close($curl);
 

--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -219,7 +219,7 @@ class HttpClient
 
         // Split the header and body
         $parts = explode("\r\n\r\n", $response, 3);
-        list($responseHeader, $responseBody) = ($parts[0] === 'HTTP/1.1 100 Continue') ? array ($parts[1], $parts[2]) : array ($parts[0], $parts[1]);
+        list($responseHeader, $responseBody) = (strpos($parts[0], "\n") == false && strpos($parts[0], 'HTTP/1.') == 0) ? array ($parts[1], $parts[2]) : array ($parts[0], $parts[1]);
 
         curl_close($curl);
 


### PR DESCRIPTION
On RHEL7, libcurl's `curl_exec` returns the data in two-part form when not using a proxy, and in three-part form when using a proxy (for example, when run with HTTPS_PROXY=myproxy:8080 in the PHP environment). The existing code presumes curl will only use the three part form with chunked transfers. This pull request proposes to better look at the first part to see if it is an isolated HTTP response line, indicating a three part response, or a multi-line response, indicating a two part response. Arguably, the strpos() is redundant, but given the vagaries of libcurl I'd rather be safe than sorry.

This fixes the side issue mentioned in #48 where the MessageBird PHP REST API reports "Got an invalid JSON response from the server." The issue could possibly be worked around by upgrading curl and/or its php wrapper, but that opens up another whole can of worms, and I'm not sure curl is wrong here in the first place.