### PR TITLE
Created Recipients object rather than it being a stdClass

### DIFF
--- a/src/MessageBird/Objects/Message.php
+++ b/src/MessageBird/Objects/Message.php
@@ -127,9 +127,9 @@ class Message extends Base
     /**
      * An array of recipients
      *
-     * @var array
+     * @var Recipients
      */
-    public $recipients = array ();
+    public $recipients;
 
     /**
      * The URL to send status delivery reports for the message to
@@ -225,14 +225,8 @@ class Message extends Base
     {
         parent::loadFromArray($object);
 
-        if (!empty($this->recipients->items)) {
-            foreach($this->recipients->items AS &$item) {
-                $Recipient = new Recipient();
-                $Recipient->loadFromArray($item);
-
-                $item = $Recipient;
-            }
-        }
+        $recipients = new Recipients();
+        $this->recipients = $recipients->loadFromArray($this->recipients);
 
         return $this;
     }

--- a/src/MessageBird/Objects/Recipient.php
+++ b/src/MessageBird/Objects/Recipient.php
@@ -35,4 +35,28 @@ class Recipient extends Base
      * @var string
      */
     public $statusDatetime;
+
+    /**
+     * @return int
+     */
+    public function getRecipient()
+    {
+        return $this->recipient;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatusDatetime()
+    {
+        return $this->statusDatetime;
+    }
 }

--- a/src/MessageBird/Objects/Recipients.php
+++ b/src/MessageBird/Objects/Recipients.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace MessageBird\Objects;
+
+/**
+ * Class Recipients
+ *
+ * @package MessageBird\Objects
+ */
+class Recipients extends Base
+{
+    /**
+     * @var int
+     */
+    public $totalCount;
+
+    /**
+     * @var int
+     */
+    public $totalSentCount;
+
+    /**
+     * @var int
+     */
+    public $totalDeliveredCount;
+
+    /**
+     * @var int
+     */
+    public $totalDeliveryFailedCount;
+
+    /**
+     * @var Recipient[]
+     */
+    public $items;
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        return $this->totalCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalSentCount()
+    {
+        return $this->totalSentCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalDeliveredCount()
+    {
+        return $this->totalDeliveredCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalDeliveryFailedCount()
+    {
+        return $this->totalDeliveryFailedCount;
+    }
+
+    /**
+     * @return Recipient[]
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param $object
+     *
+     * @return $this|void
+     */
+    public function loadFromArray($object)
+    {
+        parent::loadFromArray($object);
+
+        if (!empty($this->items)) {
+            foreach ($this->items as &$item) {
+                $recipient = new Recipient();
+                $recipient->loadFromArray($item);
+
+                $item = $recipient;
+            }
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
the recipients property in MessageBird\Objects\Message is currently just a stdClass. This PR creates a Recipients Object in its place to allow better autocomplete in IDEs