### PR TITLE
Fix README case inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We have put some self-explanatory examples in the *examples* directory, but here
 ```php
 require 'autoload.php';
 
-$MessageBird = new \MessageBird\Client('YOUR_ACCESS_KEY');
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY');
 
 ```
 
@@ -42,7 +42,7 @@ That's easy enough. Now we can query the server for information. Lets use gettin
 
 ```php
 // Get your balance
-$Balance = $MessageBird->balance->read();
+$balance = $messageBird->balance->read();
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ $balance = $messageBird->balance->read();
 ```
 
 
-Conversations Whatsapp Sandbox
+Conversations WhatsApp Sandbox
 -------------
 
-To use the whatsapp sandbox you need to add `\MessageBird\Client::ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX` to the list of features you want enabled. Don't forget to replace `YOUR_ACCESS_KEY` with your actual access key.
+To use the WhatsApp sandbox you need to add `\MessageBird\Client::ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX` to the list of features you want enabled. Don't forget to replace `YOUR_ACCESS_KEY` with your actual access key.
 
 ```php
 $messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY', null, [\MessageBird\Client::ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX]);


### PR DESCRIPTION
The README contains both StudlyCase and camelCase versions for variable naming. This PR updates all to camelCase as per PSR2.

This also fixes the capitalisation of the name "WhatsApp".