### PR TITLE
Implement partner account integration

### DIFF
--- a/examples/partner-account-create.php
+++ b/examples/partner-account-create.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once(__DIR__ . '/../autoload.php');
+
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
+
+$account = new \MessageBird\Objects\PartnerAccount\Account();
+$account->name = 'Name Test';
+$account->email = 'testSDK@messagebird.com';
+
+try {
+    $partnerAccountResult = $messageBird->partnerAccounts->create($account);
+    var_dump($partnerAccountResult);
+
+} catch (\MessageBird\Exceptions\AuthenticateException $e) {
+    // That means that your accessKey is unknown
+    echo 'wrong login';
+
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/examples/partner-account-delete.php
+++ b/examples/partner-account-delete.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once(__DIR__ . '/../autoload.php');
+
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
+
+try {
+    $partnerAccountResult = $messageBird->partnerAccounts->delete(1);
+    var_dump($partnerAccountResult);
+
+} catch (\MessageBird\Exceptions\AuthenticateException $e) {
+    // That means that your accessKey is unknown
+    echo 'wrong login';
+
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/examples/partner-account-list.php
+++ b/examples/partner-account-list.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once(__DIR__ . '/../autoload.php');
+
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
+
+try {
+    $partnerAccountResult = $messageBird->partnerAccounts->getList();
+    var_dump($partnerAccountResult);
+
+} catch (\MessageBird\Exceptions\AuthenticateException $e) {
+    // That means that your accessKey is unknown
+    echo 'wrong login';
+
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/examples/partner-account-read.php
+++ b/examples/partner-account-read.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once(__DIR__ . '/../autoload.php');
+
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
+
+try {
+    $partnerAccountResult = $messageBird->partnerAccounts->read(1);
+    var_dump($partnerAccountResult);
+
+} catch (\MessageBird\Exceptions\AuthenticateException $e) {
+    // That means that your accessKey is unknown
+    echo 'wrong login';
+
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -13,6 +13,7 @@ class Client
     const CHATAPI_ENDPOINT = 'https://chat.messagebird.com/1';
     const CONVERSATIONSAPI_ENDPOINT = 'https://conversations.messagebird.com/v1';
     const VOICEAPI_ENDPOINT = 'https://voice.messagebird.com';
+    const PARTNER_ACCOUNT_ENDPOINT = 'https://partner-accounts.messagebird.com';
 
     const ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX = 'ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX';
     const CONVERSATIONSAPI_WHATSAPP_SANDBOX_ENDPOINT = 'https://whatsapp-sandbox.messagebird.com/v1';
@@ -140,6 +141,11 @@ class Client
     public $conversationWebhooks;
 
     /**
+     * @var Resources\PartnerAccount\Accounts;
+     */
+    public $partnerAccounts;
+
+    /**
      * @var Common\HttpClient
      */
     protected $HttpClient;
@@ -160,6 +166,11 @@ class Client
     protected $VoiceAPIHttpClient;
 
     /**
+     * @var Common\HttpClient
+     */
+    protected $partnerAccountClient;
+
+    /**
      * @param string            $accessKey
      * @param Common\HttpClient $httpClient
      */
@@ -172,11 +183,13 @@ class Client
             $this->VoiceAPIHttpClient = new Common\HttpClient(self::VOICEAPI_ENDPOINT, 10, 2, array(
                 'X-MessageBird-Version' => '20170314',
            ));
+            $this->partnerAccountClient = new Common\HttpClient(self::PARTNER_ACCOUNT_ENDPOINT);
         } else {
             $this->ChatAPIHttpClient = $httpClient;
             $this->ConversationsAPIHttpClient = $httpClient;
             $this->HttpClient = $httpClient;
             $this->VoiceAPIHttpClient = $httpClient;
+            $this->partnerAccountClient = $httpClient;
         }
 
         $this->HttpClient->addUserAgentString('MessageBird/ApiClient/' . self::CLIENT_VERSION);
@@ -190,6 +203,9 @@ class Client
 
         $this->VoiceAPIHttpClient->addUserAgentString('MessageBird/ApiClient/' . self::CLIENT_VERSION);
         $this->VoiceAPIHttpClient->addUserAgentString($this->getPhpVersion());
+
+        $this->partnerAccountClient->addUserAgentString('MessageBird/ApiClient/' . self::CLIENT_VERSION);
+        $this->partnerAccountClient->addUserAgentString($this->getPhpVersion());
 
         if ($accessKey !== null) {
             $this->setAccessKey($accessKey);
@@ -218,6 +234,7 @@ class Client
         $this->conversations        = new Resources\Conversation\Conversations($this->ConversationsAPIHttpClient);
         $this->conversationMessages = new Resources\Conversation\Messages($this->ConversationsAPIHttpClient);
         $this->conversationWebhooks = new Resources\Conversation\Webhooks($this->ConversationsAPIHttpClient);
+        $this->partnerAccounts      = new Resources\PartnerAccount\Accounts($this->partnerAccountClient);
     }
 
     /**
@@ -231,6 +248,7 @@ class Client
         $this->ConversationsAPIHttpClient->setAuthentication($Authentication);
         $this->HttpClient->setAuthentication($Authentication);
         $this->VoiceAPIHttpClient->setAuthentication($Authentication);
+        $this->partnerAccountClient->setAuthentication($Authentication);
     }
 
     /**

--- a/src/MessageBird/Objects/PartnerAccount/AccessKey.php
+++ b/src/MessageBird/Objects/PartnerAccount/AccessKey.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MessageBird\Objects\PartnerAccount;
+
+use MessageBird\Objects\Base;
+
+class AccessKey extends Base
+{
+    public $id;
+
+    public $key;
+
+    public $mode;
+}

--- a/src/MessageBird/Objects/PartnerAccount/Account.php
+++ b/src/MessageBird/Objects/PartnerAccount/Account.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace MessageBird\Objects\PartnerAccount;
+
+use MessageBird\Objects\Base;
+
+class Account extends Base
+{
+    public $id;
+
+    public $name;
+
+    public $email;
+
+    public $accessKeys = [];
+
+    public $signingKey;
+
+    public function loadToJson()
+    {
+        return json_encode([
+            'name' => $this->name,
+            'email' => $this->email,
+        ]);
+    }
+
+    /**
+     * @param $object
+     *
+     * @return $this|void
+     */
+    public function loadFromArray($object)
+    {
+        parent::loadFromArray($object);
+
+        if (empty($this->accessKeys)) {
+            return $this;
+        }
+
+        foreach($this->accessKeys as &$item) {
+            $accessKey = new AccessKey();
+            $item = $accessKey->loadFromArray($item);
+        }
+
+        return $this;
+    }
+}

--- a/src/MessageBird/Resources/PartnerAccount/Accounts.php
+++ b/src/MessageBird/Resources/PartnerAccount/Accounts.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MessageBird\Resources\PartnerAccount;
+
+use MessageBird\Common\HttpClient;
+use MessageBird\Objects\PartnerAccount\Account;
+use MessageBird\Resources\Base;
+
+class Accounts extends Base
+{
+    const RESOURCE_NAME = 'child-accounts';
+
+    public function __construct(HttpClient $httpClient)
+    {
+        parent::__construct($httpClient);
+
+        $this->setObject(new Account());
+        $this->setResourceName(self::RESOURCE_NAME);
+    }
+
+    public function create($object, $query = null)
+    {
+
+        list($status, , $body) = $this->HttpClient->performHttpRequest(
+            HttpClient::REQUEST_POST,
+            self::RESOURCE_NAME,
+            null,
+            $object->loadToJson()
+        );
+
+        var_dump($status);
+        var_dump($body);
+
+        return $this->processRequest($body);
+    }
+
+    public function getList($parameters = [])
+    {
+        list($status, , $body) = $this->HttpClient->performHttpRequest(
+            HttpClient::REQUEST_GET,
+            self::RESOURCE_NAME,
+            $parameters
+        );
+
+        if ($status !== 200) {
+            return $this->processRequest($body);
+        }
+
+
+        $response = json_decode($body, true);
+
+        foreach ($response as &$item) {
+            $item = $this->getObject()->loadFromArray($item);
+        }
+
+        return $response;
+    }
+}

--- a/tests/integration/partneraccount/AccountTest.php
+++ b/tests/integration/partneraccount/AccountTest.php
@@ -1,0 +1,153 @@
+<?php
+
+class AccountTest extends BaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
+    }
+
+    public function testCreateSubAccount()
+    {
+        $account = new \MessageBird\Objects\PartnerAccount\Account();
+        $account->name = 'MessageBird';
+        $account->email = 'test@messagebird.com';
+
+        $this->mockClient
+            ->expects($this->atLeastOnce())
+            ->method('performHttpRequest')
+            ->willReturn([
+                200,
+                '',
+                '{
+                  "id": 6249799,
+                  "name": "Partner Account Sub 1",
+                  "accessKeys": [
+                    {
+                      "id": "6912036c-dd42-489b-8588-8c430aec37ef",
+                      "key": "Hb85uQhmgvXXlHK9h3SHaAC4V",
+                      "mode": "live"
+                    },
+                    {
+                      "id": "cc620896-33fb-415c-9af1-909123937321",
+                      "key": "idG2gFSMayEiFRftcStmBxc71",
+                      "mode": "test"
+                    }
+                  ],
+                  "signingKey": "7qxJg4lsDKLAEBXAdxyarcwwvDn7YB00"
+                }'
+            ]);
+        $this->mockClient
+            ->expects($this->once())
+            ->method('performHttpRequest')
+            ->with(
+                'POST',
+                'child-accounts',
+                null,
+                '{"name":"MessageBird","email":"test@messagebird.com"}'
+            );
+
+        $response = $this->client->partnerAccounts->create($account);
+
+        $this->assertNotEmpty($response->id);
+        $this->assertNotEmpty($response->name);
+        $this->assertNotEmpty($response->accessKeys);
+        $this->assertNotEmpty($response->signingKey);
+    }
+
+    public function testListSubAccount()
+    {
+        $this->mockClient
+            ->expects($this->atLeastOnce())
+            ->method('performHttpRequest')
+            ->willReturn([
+                200,
+                '',
+                '[
+                  {
+                    "id": 6249623,
+                    "name": "Partner Account 1 Sub 1",
+                    "email": "subaccount1@messagebird.com"
+                  },
+                  {
+                    "id": 6249654,
+                    "name": "Partner Account 1 Sub 2",
+                    "email": "subaccount2@messagebird.com"
+                  },
+                  {
+                    "id": 62496654,
+                    "name": "Partner Account 1 Sub 3",
+                    "email": "subaccount3@messagebird.com"
+                  }
+                ]'
+            ]);
+        $this->mockClient
+            ->expects($this->once())
+            ->method('performHttpRequest')
+            ->with(
+                'GET',
+                'child-accounts'
+            );
+
+        $response = $this->client->partnerAccounts->getList();
+        $this->assertCount(3, $response);
+        foreach ($response as $item) {
+            $this->assertNotEmpty($item->id);
+            $this->assertNotEmpty($item->name);
+            $this->assertNotEmpty($item->email);
+        }
+    }
+
+    public function testReadSubAccount()
+    {
+        $this->mockClient
+            ->expects($this->atLeastOnce())
+            ->method('performHttpRequest')
+            ->willReturn([
+                200,
+                '',
+                '{
+                  "id": 6249609,
+                  "name": "Partner Account 1 Sub 1",
+                  "email": "subaccount1@messagebird.com"
+                }'
+            ]);
+        $this->mockClient
+            ->expects($this->once())
+            ->method('performHttpRequest')
+            ->with(
+                'GET',
+                'child-accounts/1'
+            );
+
+        $response = $this->client->partnerAccounts->read(1);
+
+        $this->assertNotEmpty($response->id);
+        $this->assertNotEmpty($response->name);
+        $this->assertNotEmpty($response->email);
+    }
+
+    public function testDeleteSubAccount()
+    {
+        $this->mockClient
+            ->expects($this->atLeastOnce())
+            ->method('performHttpRequest')
+            ->willReturn([
+                204,
+                '',
+                ''
+            ]);
+        $this->mockClient
+            ->expects($this->once())
+            ->method('performHttpRequest')
+            ->with(
+                'DELETE',
+                'child-accounts/1'
+            );
+
+        $response = $this->client->partnerAccounts->delete(1);
+
+        $this->assertTrue($response);
+    }
+}


### PR DESCRIPTION
Integrate the SDK with the partner account API to be able to CRUD sub
accounts for the user which has the privilege to use the Partner Account
feature.

You can find the Partner Account documentation on the MessageBird
website (https://developers.messagebird.com/)