### PR TITLE
Update PHPUnit to 8.x and drop unsupported versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 .DS_Store
 .idea/
+.phpunit.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,10 @@
 language: php
-dist: trusty
+dist: xenial
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
     - 7.3
-    - hhvm
-    - hhvm-nightly
-
-matrix:
-    allow_failures:
-        - php: hhvm
-        - php: hhvm-nightly
+    - 7.4
 
 before_script:
-    - if [[ "$TRAVIS_PHP_VERSION" == "hhvm"* ]]; then curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
     - composer install
 
 script: phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/polyfill-php56": "^1.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.25"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-curl": "*",
-        "symfony/polyfill-php56": "^1.10"
+        "php": ">=7.2.0",
+        "ext-curl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="autoload.php"
 >
     <testsuites>

--- a/tests/integration/BaseTest.php
+++ b/tests/integration/BaseTest.php
@@ -1,11 +1,8 @@
 <?php
-// Starting from PHPUnit 6, PHPUnit classes are namespaced. This alias ensures our tests still run
-// with PHPUnit >=6. See: https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0
-if (!class_exists('PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
-    class_alias('\PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
-}
 
-class BaseTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BaseTest extends TestCase
 {
     /** @var \MessageBird\Client */
     protected $client;
@@ -13,7 +10,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
     /** @var PHPUnit_Framework_MockObject_MockObject */
     protected $mockClient;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockClient = $this->getMockBuilder("\MessageBird\Common\HttpClient")->setConstructorArgs(array("fake.messagebird.dev"))->getMock();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
@@ -43,6 +40,8 @@ class BaseTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('MessageBird\Resources\Chat\Platform', $MessageBird->chatPlatforms);
         $this->assertInstanceOf('MessageBird\Resources\Chat\Channel', $MessageBird->chatChannels);
         $this->assertInstanceOf('MessageBird\Resources\Chat\Contact', $MessageBird->chatContacts);
+        $this->assertInstanceOf('MessageBird\Resources\AvailableNumbers', $MessageBird->availableNumbers);
+        $this->assertInstanceOf('MessageBird\Resources\PurchasedNumbers', $MessageBird->purchasedNumbers);
 
     }
 

--- a/tests/integration/BaseTest.php
+++ b/tests/integration/BaseTest.php
@@ -40,9 +40,6 @@ class BaseTest extends TestCase
         $this->assertInstanceOf('MessageBird\Resources\Chat\Platform', $MessageBird->chatPlatforms);
         $this->assertInstanceOf('MessageBird\Resources\Chat\Channel', $MessageBird->chatChannels);
         $this->assertInstanceOf('MessageBird\Resources\Chat\Contact', $MessageBird->chatContacts);
-        $this->assertInstanceOf('MessageBird\Resources\AvailableNumbers', $MessageBird->availableNumbers);
-        $this->assertInstanceOf('MessageBird\Resources\PurchasedNumbers', $MessageBird->purchasedNumbers);
-
     }
 
     public function testHttpClientMock()

--- a/tests/integration/HttpClientTest.php
+++ b/tests/integration/HttpClientTest.php
@@ -16,12 +16,10 @@ class HttpClientTest extends BaseTest
         $this->assertSame(Client::ENDPOINT.'/a?b=1', $url);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Timeout must be an int > 0, got "integer 0".$#
-     */
     public function testHttpClientInvalidTimeout()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/^Timeout must be an int > 0, got "integer 0".$/');
         new HttpClient(Client::ENDPOINT, 0);
     }
 

--- a/tests/integration/HttpClientTest.php
+++ b/tests/integration/HttpClientTest.php
@@ -33,12 +33,10 @@ class HttpClientTest extends BaseTest
         $this->doAssertionToNotBeConsideredRiskyTest();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Connection timeout must be an int >= 0, got "stdClass".$#
-     */
     public function testHttpClientInvalidConnectionTimeout()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('#^Connection timeout must be an int >= 0, got "stdClass".$#');
         new HttpClient(Client::ENDPOINT, 10, new \stdClass());
     }
 
@@ -54,12 +52,11 @@ class HttpClientTest extends BaseTest
 
     /**
      * Test that requests can only be made when there is an Authentication set
-     *
-     * @expectedException \MessageBird\Exceptions\AuthenticateException
-     * @expectedExceptionMessageRegExp #Can not perform API Request without Authentication#
      */
     public function testHttpClientWithoutAuthenticationException()
     {
+        $this->expectException('MessageBird\Exceptions\AuthenticateException');
+        $this->expectExceptionMessageRegExp('#Can not perform API Request without Authentication#');
         $client = new HttpClient(Client::ENDPOINT);
         $client->performHttpRequest('foo', 'bar');
     }

--- a/tests/integration/HttpClientTest.php
+++ b/tests/integration/HttpClientTest.php
@@ -35,8 +35,8 @@ class HttpClientTest extends BaseTest
 
     public function testHttpClientInvalidConnectionTimeout()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('#^Connection timeout must be an int >= 0, got "stdClass".$#');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/^Connection timeout must be an int >= 0, got "stdClass".$/');
         new HttpClient(Client::ENDPOINT, 10, new \stdClass());
     }
 
@@ -55,8 +55,8 @@ class HttpClientTest extends BaseTest
      */
     public function testHttpClientWithoutAuthenticationException()
     {
-        $this->expectException('MessageBird\Exceptions\AuthenticateException');
-        $this->expectExceptionMessageRegExp('#Can not perform API Request without Authentication#');
+        $this->expectException(\MessageBird\Exceptions\AuthenticateException::class);
+        $this->expectExceptionMessageRegExp('/Can not perform API Request without Authentication/');
         $client = new HttpClient(Client::ENDPOINT);
         $client->performHttpRequest('foo', 'bar');
     }

--- a/tests/integration/balance/BalanceTest.php
+++ b/tests/integration/balance/BalanceTest.php
@@ -1,7 +1,7 @@
 <?php
 class BalanceTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
@@ -12,6 +12,7 @@ class BalanceTest extends BaseTest
      */
     public function testReadBalance()
     {
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'balance', null, null);
         $this->client->balance->read();
     }

--- a/tests/integration/balance/BalanceTest.php
+++ b/tests/integration/balance/BalanceTest.php
@@ -9,7 +9,6 @@ class BalanceTest extends BaseTest
 
     public function testReadBalance()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'balance', null, null);
         $this->client->balance->read();

--- a/tests/integration/balance/BalanceTest.php
+++ b/tests/integration/balance/BalanceTest.php
@@ -7,11 +7,9 @@ class BalanceTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testReadBalance()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'balance', null, null);
         $this->client->balance->read();

--- a/tests/integration/chat/ChatTest.php
+++ b/tests/integration/chat/ChatTest.php
@@ -1,7 +1,7 @@
 <?php
 class ChatTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/chat/ChatTest.php
+++ b/tests/integration/chat/ChatTest.php
@@ -21,14 +21,14 @@ class ChatTest extends BaseTest
 
     public function testListChatMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages', array ('offset' => 100, 'limit' => 30), null);
         $ChatMessageList = $this->client->chatMessages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadChatMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages/id', null, null);
         $ChatMessageList = $this->client->chatMessages->read("id");
     }
@@ -53,21 +53,21 @@ class ChatTest extends BaseTest
 
     public function testListChatChannels()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'channels', array ('offset' => 100, 'limit' => 30), null);
         $ChannelList = $this->client->chatChannels->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadChatChannel()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'channels/id', null, null);
         $Channel = $this->client->chatChannels->read("id");
     }
 
     public function testDeleteChannel()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'channels/id', null, null);
         $Channel = $this->client->chatChannels->delete("id");
     }
@@ -85,35 +85,35 @@ class ChatTest extends BaseTest
 
     public function testListChatPlatforms()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'platforms', array ('offset' => 100, 'limit' => 30), null);
         $ChannelList = $this->client->chatPlatforms->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadChatPlatform()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'platforms/id', null, null);
         $Channel = $this->client->chatPlatforms->read("id");
     }
 
     public function testListChatContacts()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts', array ('offset' => 100, 'limit' => 30), null);
         $ContactList = $this->client->chatContacts->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadChatContact()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts/id', null, null);
         $Contact = $this->client->chatContacts->read("id");
     }
 
     public function testDeleteContact()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'contacts/id', null, null);
         $contact = $this->client->chatContacts->delete("id");
     }

--- a/tests/integration/chat/ChatTest.php
+++ b/tests/integration/chat/ChatTest.php
@@ -19,20 +19,16 @@ class ChatTest extends BaseTest
         $this->client->chatMessages->create($ChatMessage);
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListChatMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages', array ('offset' => 100, 'limit' => 30), null);
         $ChatMessageList = $this->client->chatMessages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadChatMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages/id', null, null);
         $ChatMessageList = $this->client->chatMessages->read("id");
     }
@@ -55,29 +51,23 @@ class ChatTest extends BaseTest
         $this->client->chatChannels->create($ChatChannel);
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListChatChannels()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'channels', array ('offset' => 100, 'limit' => 30), null);
         $ChannelList = $this->client->chatChannels->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadChatChannel()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'channels/id', null, null);
         $Channel = $this->client->chatChannels->read("id");
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testDeleteChannel()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'channels/id', null, null);
         $Channel = $this->client->chatChannels->delete("id");
     }
@@ -93,47 +83,37 @@ class ChatTest extends BaseTest
         $this->client->chatChannels->update($ChatChannel,'234agfgADFH2974gaADFH3hudf9h');
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListChatPlatforms()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'platforms', array ('offset' => 100, 'limit' => 30), null);
         $ChannelList = $this->client->chatPlatforms->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadChatPlatform()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'platforms/id', null, null);
         $Channel = $this->client->chatPlatforms->read("id");
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListChatContacts()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts', array ('offset' => 100, 'limit' => 30), null);
         $ContactList = $this->client->chatContacts->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadChatContact()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts/id', null, null);
         $Contact = $this->client->chatContacts->read("id");
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testDeleteContact()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'contacts/id', null, null);
         $contact = $this->client->chatContacts->delete("id");
     }

--- a/tests/integration/contacts/ContactTest.php
+++ b/tests/integration/contacts/ContactTest.php
@@ -1,7 +1,7 @@
 <?php
 class ContactTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/contacts/ContactTest.php
+++ b/tests/integration/contacts/ContactTest.php
@@ -47,21 +47,21 @@ class ContactTest extends BaseTest
 
     public function testListContacts()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts', array ('offset' => 100, 'limit' => 30), null);
         $this->client->contacts->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testViewContact()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts/contact_id', null, null);
         $this->client->contacts->read("contact_id");
     }
 
     public function testDeleteContact()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'contacts/contact_id', null, null);
         $this->client->contacts->delete("contact_id");
     }

--- a/tests/integration/contacts/ContactTest.php
+++ b/tests/integration/contacts/ContactTest.php
@@ -45,29 +45,23 @@ class ContactTest extends BaseTest
         $this->client->contacts->create($Contact);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testListContacts()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts', array ('offset' => 100, 'limit' => 30), null);
         $this->client->contacts->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testViewContact()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'contacts/contact_id', null, null);
         $this->client->contacts->read("contact_id");
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testDeleteContact()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'contacts/contact_id', null, null);
         $this->client->contacts->delete("contact_id");
     }

--- a/tests/integration/conversation/ConversationMessageTest.php
+++ b/tests/integration/conversation/ConversationMessageTest.php
@@ -46,7 +46,7 @@ class ConversationMessageTest extends BaseTest
         "type": "video"
     }';
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/integration/conversation/ConversationTest.php
+++ b/tests/integration/conversation/ConversationTest.php
@@ -94,7 +94,7 @@ class ConversationTest extends BaseTest
         "lastUsedChannelId": "channel-id"
     }';
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/integration/conversation/ConversationWebhookTest.php
+++ b/tests/integration/conversation/ConversationWebhookTest.php
@@ -37,7 +37,7 @@ class ConversationWebhookTest extends BaseTest
         "updatedDatetime": "2018-07-20T12:13:51+00:00"
     }';
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/integration/groups/GroupTest.php
+++ b/tests/integration/groups/GroupTest.php
@@ -1,7 +1,7 @@
 <?php
 class GroupTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/groups/GroupTest.php
+++ b/tests/integration/groups/GroupTest.php
@@ -27,29 +27,23 @@ class GroupTest extends BaseTest
         $this->client->groups->create($Group);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testListGroups()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'groups', array ('offset' => 100, 'limit' => 30), null);
         $this->client->groups->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testViewGroup()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'groups/group_id', null, null);
         $this->client->groups->read("group_id");
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testDeleteGroup()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'groups/group_id', null, null);
         $this->client->groups->delete("group_id");
     }

--- a/tests/integration/groups/GroupTest.php
+++ b/tests/integration/groups/GroupTest.php
@@ -29,21 +29,21 @@ class GroupTest extends BaseTest
 
     public function testListGroups()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'groups', array ('offset' => 100, 'limit' => 30), null);
         $this->client->groups->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testViewGroup()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'groups/group_id', null, null);
         $this->client->groups->read("group_id");
     }
 
     public function testDeleteGroup()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'groups/group_id', null, null);
         $this->client->groups->delete("group_id");
     }

--- a/tests/integration/hlr/HlrTest.php
+++ b/tests/integration/hlr/HlrTest.php
@@ -1,7 +1,7 @@
 <?php
 class HlrTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/hlr/HlrTest.php
+++ b/tests/integration/hlr/HlrTest.php
@@ -9,7 +9,7 @@ class HlrTest extends BaseTest
 
     public function testCreateHlr()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 'MessageBird';
         $Hlr->reference  = "yoloswag3000";
@@ -21,7 +21,7 @@ class HlrTest extends BaseTest
 
     public function testReadHlr()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'hlr/message_id', null, null);
         $this->client->hlr->read("message_id");
     }

--- a/tests/integration/hlr/HlrTest.php
+++ b/tests/integration/hlr/HlrTest.php
@@ -7,11 +7,9 @@ class HlrTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testCreateHlr()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 'MessageBird';
         $Hlr->reference  = "yoloswag3000";
@@ -21,11 +19,9 @@ class HlrTest extends BaseTest
     }
 
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testReadHlr()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'hlr/message_id', null, null);
         $this->client->hlr->read("message_id");
     }

--- a/tests/integration/lookup/LookupTest.php
+++ b/tests/integration/lookup/LookupTest.php
@@ -1,7 +1,7 @@
 <?php
 class LookupTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/lookup/LookupTest.php
+++ b/tests/integration/lookup/LookupTest.php
@@ -7,38 +7,30 @@ class LookupTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testReadLookup()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/31612345678', null, null);
         $this->client->lookup->read(31612345678);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testReadLookupWithEmptyNumber()
     {
+        $this->expectException('InvalidArgumentException');
         $this->client->lookup->read(null);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testReadLookupWithCountryCode()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $params = array("countryCode" => "NL");
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/612345678', $params, null);
         $this->client->lookup->read(612345678, $params["countryCode"]);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testCreateLookupHlr()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 31612345678;
         $Hlr->reference  = 'Yoloswag3007';
@@ -48,21 +40,17 @@ class LookupTest extends BaseTest
         $this->client->lookupHlr->create($Hlr);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateLookupHlrWithEmptyNumber()
     {
+        $this->expectException('InvalidArgumentException');
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = null;
         $this->client->lookupHlr->create($Hlr);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testCreateLookupHlrWithCountryCode()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 612345678;
         $Hlr->reference  = "CoolReference";
@@ -74,28 +62,22 @@ class LookupTest extends BaseTest
         $this->client->lookupHlr->create($Hlr, $params["countryCode"]);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testReadLookupHlr()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/31612345678/hlr', null, null);
         $this->client->lookupHlr->read(31612345678);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testReadLookupHlrWithEmptyNumber()
     {
+        $this->expectException('InvalidArgumentException');
         $this->client->lookupHlr->read(null);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testReadLookupHlrWithCountryCode()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $params = array("countryCode" => "NL");
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/612345678/hlr', $params, null);
         $this->client->lookupHlr->read(612345678, $params["countryCode"]);

--- a/tests/integration/lookup/LookupTest.php
+++ b/tests/integration/lookup/LookupTest.php
@@ -9,20 +9,20 @@ class LookupTest extends BaseTest
 
     public function testReadLookup()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/31612345678', null, null);
         $this->client->lookup->read(31612345678);
     }
 
     public function testReadLookupWithEmptyNumber()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->client->lookup->read(null);
     }
 
     public function testReadLookupWithCountryCode()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $params = array("countryCode" => "NL");
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/612345678', $params, null);
         $this->client->lookup->read(612345678, $params["countryCode"]);
@@ -30,7 +30,7 @@ class LookupTest extends BaseTest
 
     public function testCreateLookupHlr()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 31612345678;
         $Hlr->reference  = 'Yoloswag3007';
@@ -42,7 +42,7 @@ class LookupTest extends BaseTest
 
     public function testCreateLookupHlrWithEmptyNumber()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = null;
         $this->client->lookupHlr->create($Hlr);
@@ -50,7 +50,7 @@ class LookupTest extends BaseTest
 
     public function testCreateLookupHlrWithCountryCode()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Hlr             = new \MessageBird\Objects\Hlr();
         $Hlr->msisdn     = 612345678;
         $Hlr->reference  = "CoolReference";
@@ -64,20 +64,20 @@ class LookupTest extends BaseTest
 
     public function testReadLookupHlr()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/31612345678/hlr', null, null);
         $this->client->lookupHlr->read(31612345678);
     }
 
     public function testReadLookupHlrWithEmptyNumber()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->client->lookupHlr->read(null);
     }
 
     public function testReadLookupHlrWithCountryCode()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $params = array("countryCode" => "NL");
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'lookup/612345678/hlr', $params, null);
         $this->client->lookupHlr->read(612345678, $params["countryCode"]);

--- a/tests/integration/messages/MessagesTest.php
+++ b/tests/integration/messages/MessagesTest.php
@@ -1,7 +1,7 @@
 <?php
 class MessageTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/messages/MessagesTest.php
+++ b/tests/integration/messages/MessagesTest.php
@@ -52,7 +52,7 @@ class MessageTest extends BaseTest
 
     public function testPremiumSmsMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -64,7 +64,7 @@ class MessageTest extends BaseTest
 
     public function testBinarySmsMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -77,7 +77,7 @@ class MessageTest extends BaseTest
 
     public function testFlashSmsMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -91,21 +91,21 @@ class MessageTest extends BaseTest
 
     public function testListMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages', array ('offset' => 100, 'limit' => 30), null);
         $this->client->messages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages/message_id', null, null);
         $this->client->messages->read("message_id");
     }
 
     public function testDeleteMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'messages/message_id', null, null);
         $this->client->messages->delete("message_id");
     }

--- a/tests/integration/messages/MessagesTest.php
+++ b/tests/integration/messages/MessagesTest.php
@@ -50,11 +50,9 @@ class MessageTest extends BaseTest
         $this->client->messages->create($Message);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testPremiumSmsMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -64,11 +62,9 @@ class MessageTest extends BaseTest
         $this->client->messages->create($Message);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testBinarySmsMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -79,11 +75,9 @@ class MessageTest extends BaseTest
     }
 
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testFlashSmsMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Message             = new \MessageBird\Objects\Message();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -95,29 +89,23 @@ class MessageTest extends BaseTest
     }
 
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testListMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages', array ('offset' => 100, 'limit' => 30), null);
         $this->client->messages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testReadMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'messages/message_id', null, null);
         $this->client->messages->read("message_id");
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testDeleteMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'messages/message_id', null, null);
         $this->client->messages->delete("message_id");
     }

--- a/tests/integration/mms/MmsTest.php
+++ b/tests/integration/mms/MmsTest.php
@@ -3,7 +3,7 @@ class MmsTest extends BaseTest
 {
     public function testCreateMmsFail()
     {
-        $this->expectException('MessageBird\Exceptions\RequestException');
+        $this->expectException(\MessageBird\Exceptions\RequestException::class);
         $MmsMessage = new \MessageBird\Objects\MmsMessage();
 
         $this->mockClient->expects($this->once())
@@ -64,7 +64,7 @@ class MmsTest extends BaseTest
 
     public function testDeleteMms()
     {
-        $this->expectException('MessageBird\Exceptions\RequestException');
+        $this->expectException(\MessageBird\Exceptions\RequestException::class);
         $this->mockClient->expects($this->exactly(2))
             ->method('performHttpRequest')
             ->with('DELETE', 'mms/message_id', null, null)
@@ -81,7 +81,7 @@ class MmsTest extends BaseTest
 
     public function testReadMms()
     {
-        $this->expectException('MessageBird\Exceptions\RequestException');
+        $this->expectException(\MessageBird\Exceptions\RequestException::class);
         $dummyMessage = $this->generateDummyMessage();
 
         $this->mockClient->expects($this->exactly(2))

--- a/tests/integration/mms/MmsTest.php
+++ b/tests/integration/mms/MmsTest.php
@@ -1,11 +1,9 @@
 <?php
 class MmsTest extends BaseTest
 {
-    /**
-     * @expectedException \MessageBird\Exceptions\RequestException
-     */
     public function testCreateMmsFail()
     {
+        $this->expectException('MessageBird\Exceptions\RequestException');
         $MmsMessage = new \MessageBird\Objects\MmsMessage();
 
         $this->mockClient->expects($this->once())
@@ -64,11 +62,9 @@ class MmsTest extends BaseTest
 
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\RequestException
-     */
     public function testDeleteMms()
     {
+        $this->expectException('MessageBird\Exceptions\RequestException');
         $this->mockClient->expects($this->exactly(2))
             ->method('performHttpRequest')
             ->with('DELETE', 'mms/message_id', null, null)
@@ -83,11 +79,9 @@ class MmsTest extends BaseTest
         $this->client->mmsMessages->delete('message_id');
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\RequestException
-     */
     public function testReadMms()
     {
+        $this->expectException('MessageBird\Exceptions\RequestException');
         $dummyMessage = $this->generateDummyMessage();
 
         $this->mockClient->expects($this->exactly(2))

--- a/tests/integration/partneraccount/AccountTest.php
+++ b/tests/integration/partneraccount/AccountTest.php
@@ -2,7 +2,7 @@
 
 class AccountTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/verify/VerifyTest.php
+++ b/tests/integration/verify/VerifyTest.php
@@ -1,7 +1,7 @@
 <?php
 class VerifyTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/verify/VerifyTest.php
+++ b/tests/integration/verify/VerifyTest.php
@@ -7,11 +7,9 @@ class VerifyTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testGenerateOtp()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Verify             = new \MessageBird\Objects\Verify();
         $Verify->recipient  = 31612345678;
         $Verify->reference  = "Yoloswag3000";
@@ -21,11 +19,9 @@ class VerifyTest extends BaseTest
         $this->client->verify->create($Verify);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testVerifyOtp()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Verify            = new \MessageBird\Objects\Verify();
         $Verify->recipient = 31612345678;
         $Verify->reference = 'Yoloswag3000';

--- a/tests/integration/verify/VerifyTest.php
+++ b/tests/integration/verify/VerifyTest.php
@@ -9,7 +9,7 @@ class VerifyTest extends BaseTest
 
     public function testGenerateOtp()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Verify             = new \MessageBird\Objects\Verify();
         $Verify->recipient  = 31612345678;
         $Verify->reference  = "Yoloswag3000";
@@ -21,7 +21,7 @@ class VerifyTest extends BaseTest
 
     public function testVerifyOtp()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Verify            = new \MessageBird\Objects\Verify();
         $Verify->recipient = 31612345678;
         $Verify->reference = 'Yoloswag3000';

--- a/tests/integration/voice/VoiceTest.php
+++ b/tests/integration/voice/VoiceTest.php
@@ -5,7 +5,7 @@ class VoiceTest extends BaseTest
     /** @var \MessageBird\Client client */
     public $client;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/voice/VoiceTest.php
+++ b/tests/integration/voice/VoiceTest.php
@@ -11,11 +11,9 @@ class VoiceTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceCall()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls', array(
             'offset' => 100,
             'limit' => 30,
@@ -23,11 +21,9 @@ class VoiceTest extends BaseTest
         $this->client->voiceCalls->getList(array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceCall()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foobar', null, null);
         $this->client->voiceCalls->read('foobar');
     }
@@ -66,11 +62,9 @@ class VoiceTest extends BaseTest
         $this->client->voiceCalls->create($voiceCall);
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceLegs()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foobar/legs', array(
             'offset' => 100,
             'limit' => 30,
@@ -78,20 +72,16 @@ class VoiceTest extends BaseTest
         $this->client->voiceLegs->getList('foobar', array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceLeg()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar', null, null);
         $this->client->voiceLegs->read('foo', 'bar');
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceRecordings()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings', array(
             'offset' => 100,
             'limit' => 30,
@@ -99,21 +89,17 @@ class VoiceTest extends BaseTest
         $this->client->voiceRecordings->getList('foo', 'bar', array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceRecording()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz', null, null);
         $this->client->voiceRecordings->read('foo', 'bar', 'baz');
     }
 
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testDownloadVoiceRecording()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz.wav', null, null);
         $this->client->voiceRecordings->download('foo', 'bar', 'baz');
     }
@@ -139,11 +125,9 @@ class VoiceTest extends BaseTest
         $this->client->voiceTranscriptions->create('foo', 'bar', 'baz');
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceTranscriptions()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions', array(
             'offset' => 100,
             'limit' => 30,
@@ -151,29 +135,23 @@ class VoiceTest extends BaseTest
         $this->client->voiceTranscriptions->getList('foo', 'bar', 'baz', array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceTranscription()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions/bups', null, null);
         $this->client->voiceTranscriptions->read('foo', 'bar', 'baz', 'bups');
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testDownloadVoiceTranscription()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions/bups.txt', null, null);
         $this->client->voiceTranscriptions->download('foo', 'bar', 'baz', 'bups');
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceWebhooks()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'webhooks', array(
             'offset' => 100,
             'limit' => 30,
@@ -181,11 +159,9 @@ class VoiceTest extends BaseTest
         $this->client->voiceWebhooks->getList(array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceWebhook()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'webhooks/foobar', null, null);
         $this->client->voiceWebhooks->read('foobar');
     }
@@ -255,11 +231,9 @@ class VoiceTest extends BaseTest
     }
 
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testListVoiceCallFlows()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'call-flows', array(
             'offset' => 100,
             'limit' => 30,
@@ -267,11 +241,9 @@ class VoiceTest extends BaseTest
         $this->client->voiceCallFlows->getList(array('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException MessageBird\Exceptions\ServerException
-     */
     public function testReadVoiceCallFlow()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'call-flows/foobar', null, null);
         $this->client->voiceCallFlows->read('foobar');
     }

--- a/tests/integration/voice/VoiceTest.php
+++ b/tests/integration/voice/VoiceTest.php
@@ -13,7 +13,7 @@ class VoiceTest extends BaseTest
 
     public function testListVoiceCall()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls', array(
             'offset' => 100,
             'limit' => 30,
@@ -23,7 +23,7 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceCall()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foobar', null, null);
         $this->client->voiceCalls->read('foobar');
     }
@@ -64,7 +64,7 @@ class VoiceTest extends BaseTest
 
     public function testListVoiceLegs()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foobar/legs', array(
             'offset' => 100,
             'limit' => 30,
@@ -74,14 +74,14 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceLeg()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar', null, null);
         $this->client->voiceLegs->read('foo', 'bar');
     }
 
     public function testListVoiceRecordings()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings', array(
             'offset' => 100,
             'limit' => 30,
@@ -91,7 +91,7 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceRecording()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz', null, null);
         $this->client->voiceRecordings->read('foo', 'bar', 'baz');
     }
@@ -99,7 +99,7 @@ class VoiceTest extends BaseTest
 
     public function testDownloadVoiceRecording()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz.wav', null, null);
         $this->client->voiceRecordings->download('foo', 'bar', 'baz');
     }
@@ -127,7 +127,7 @@ class VoiceTest extends BaseTest
 
     public function testListVoiceTranscriptions()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions', array(
             'offset' => 100,
             'limit' => 30,
@@ -137,21 +137,21 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceTranscription()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions/bups', null, null);
         $this->client->voiceTranscriptions->read('foo', 'bar', 'baz', 'bups');
     }
 
     public function testDownloadVoiceTranscription()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'calls/foo/legs/bar/recordings/baz/transcriptions/bups.txt', null, null);
         $this->client->voiceTranscriptions->download('foo', 'bar', 'baz', 'bups');
     }
 
     public function testListVoiceWebhooks()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'webhooks', array(
             'offset' => 100,
             'limit' => 30,
@@ -161,7 +161,7 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceWebhook()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'webhooks/foobar', null, null);
         $this->client->voiceWebhooks->read('foobar');
     }
@@ -233,7 +233,7 @@ class VoiceTest extends BaseTest
 
     public function testListVoiceCallFlows()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'call-flows', array(
             'offset' => 100,
             'limit' => 30,
@@ -243,7 +243,7 @@ class VoiceTest extends BaseTest
 
     public function testReadVoiceCallFlow()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'call-flows/foobar', null, null);
         $this->client->voiceCallFlows->read('foobar');
     }

--- a/tests/integration/voicemessages/VoiceMessagesTest.php
+++ b/tests/integration/voicemessages/VoiceMessagesTest.php
@@ -1,7 +1,7 @@
 <?php
 class VoiceMessagesTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);

--- a/tests/integration/voicemessages/VoiceMessagesTest.php
+++ b/tests/integration/voicemessages/VoiceMessagesTest.php
@@ -7,11 +7,9 @@ class VoiceMessagesTest extends BaseTest
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testVoiceMessageCreate()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $Message             = new \MessageBird\Objects\VoiceMessage();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -22,29 +20,23 @@ class VoiceMessagesTest extends BaseTest
         $this->client->voicemessages->create($Message);
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-     */
     public function testListMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages', array ('offset' => 100, 'limit' => 30), null);
         $this->client->voicemessages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testReadMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages/message_id', null, null);
         $this->client->voicemessages->read("message_id");
     }
 
-    /**
-     * @expectedException     MessageBird\Exceptions\ServerException
-       */
     public function testDeleteMessage()
     {
+        $this->expectException('MessageBird\Exceptions\ServerException');
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'voicemessages/message_id', null, null);
         $this->client->voicemessages->delete("message_id");
     }

--- a/tests/integration/voicemessages/VoiceMessagesTest.php
+++ b/tests/integration/voicemessages/VoiceMessagesTest.php
@@ -9,7 +9,7 @@ class VoiceMessagesTest extends BaseTest
 
     public function testVoiceMessageCreate()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $Message             = new \MessageBird\Objects\VoiceMessage();
         $Message->originator = 'MessageBird';
         $Message->recipients = array(31612345678);
@@ -22,21 +22,21 @@ class VoiceMessagesTest extends BaseTest
 
     public function testListMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages', array ('offset' => 100, 'limit' => 30), null);
         $this->client->voicemessages->getList(array ('offset' => 100, 'limit' => 30));
     }
 
     public function testReadMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("GET", 'voicemessages/message_id', null, null);
         $this->client->voicemessages->read("message_id");
     }
 
     public function testDeleteMessage()
     {
-        $this->expectException('MessageBird\Exceptions\ServerException');
+        $this->expectException(\MessageBird\Exceptions\ServerException::class);
         $this->mockClient->expects($this->once())->method('performHttpRequest')->with("DELETE", 'voicemessages/message_id', null, null);
         $this->client->voicemessages->delete("message_id");
     }

--- a/tests/unit/RequestValidatorTest.php
+++ b/tests/unit/RequestValidatorTest.php
@@ -2,8 +2,9 @@
 
 use MessageBird\Objects\SignedRequest;
 use MessageBird\RequestValidator;
+use PHPUnit\Framework\TestCase;
 
-class RequestValidatorTest extends PHPUnit_Framework_TestCase
+class RequestValidatorTest extends TestCase
 {
     public function testVerify()
     {

--- a/tests/unit/SignedRequestTest.php
+++ b/tests/unit/SignedRequestTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use MessageBird\Objects\SignedRequest;
+use PHPUnit\Framework\TestCase;
 
-class SignedRequestTest extends PHPUnit_Framework_TestCase
+class SignedRequestTest extends TestCase
 {
     public function testCreate()
     {

--- a/tests/unit/SignedRequestTest.php
+++ b/tests/unit/SignedRequestTest.php
@@ -59,7 +59,7 @@ class SignedRequestTest extends TestCase
 
     public function testLoadInvalidQuery()
     {
-        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectException(\MessageBird\Exceptions\ValidationException::class);
         $this->expectExceptionMessage('query');
         $query = null;
         $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
@@ -77,7 +77,7 @@ class SignedRequestTest extends TestCase
 
     public function testLoadInvalidSignature()
     {
-        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectException(\MessageBird\Exceptions\ValidationException::class);
         $this->expectExceptionMessage('signature');
         $query = array(
             'recipient'      => '31612345678',
@@ -103,7 +103,7 @@ class SignedRequestTest extends TestCase
 
     public function testLoadInvalidTimestamp()
     {
-        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectException(\MessageBird\Exceptions\ValidationException::class);
         $this->expectExceptionMessage('requestTimestamp');
         $query = array(
             'recipient'      => '31612345678',
@@ -129,7 +129,7 @@ class SignedRequestTest extends TestCase
 
     public function testLoadInvalidBody()
     {
-        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectException(\MessageBird\Exceptions\ValidationException::class);
         $this->expectExceptionMessage('body');
         $query = array(
             'recipient'      => '31612345678',

--- a/tests/unit/SignedRequestTest.php
+++ b/tests/unit/SignedRequestTest.php
@@ -57,12 +57,10 @@ class SignedRequestTest extends TestCase
         self::assertEquals($signature, $request->signature);
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\ValidationException
-     * @expectedExceptionMessage query
-     */
     public function testLoadInvalidQuery()
     {
+        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectExceptionMessage('query');
         $query = null;
         $signature = '2bl+38H4oHVg03pC3bk2LvCB0IHFgfC4cL5HPQ0LdmI=';
         $requestTimestamp = 1547198231;
@@ -77,12 +75,10 @@ class SignedRequestTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\ValidationException
-     * @expectedExceptionMessage signature
-     */
     public function testLoadInvalidSignature()
     {
+        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectExceptionMessage('signature');
         $query = array(
             'recipient'      => '31612345678',
             'reference'      => 'FOO',
@@ -105,12 +101,10 @@ class SignedRequestTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\ValidationException
-     * @expectedExceptionMessage requestTimestamp
-     */
     public function testLoadInvalidTimestamp()
     {
+        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectExceptionMessage('requestTimestamp');
         $query = array(
             'recipient'      => '31612345678',
             'reference'      => 'FOO',
@@ -133,12 +127,10 @@ class SignedRequestTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \MessageBird\Exceptions\ValidationException
-     * @expectedExceptionMessage body
-     */
     public function testLoadInvalidBody()
     {
+        $this->expectException('MessageBird\Exceptions\ValidationException');
+        $this->expectExceptionMessage('body');
         $query = array(
             'recipient'      => '31612345678',
             'reference'      => 'FOO',


### PR DESCRIPTION
# Motivation

Closes #98 
Closes #79

PHPUnit 4.x is pretty ancient, and on recent versions it runs into [this issue](https://github.com/sebastianbergmann/phpunit/issues/3728) with invoking a fully deprecated method.

It seems that tests in Travis have not been running in 7.x for a while as well.

[Composer also does not support HHVM](https://github.com/composer/composer/issues/8127), so I've removed it from the matrix as well.

# Changes

- Update PHPUnit to 8
- Refactor deprecated annotations
- Remove 5.x PHP versions from CI matrix

# Notes

I'm not sure if there's a requirement to keep support for 5.x (supported until late 2018). PHPUnit only supported 5.6 until PHPUnit 5.x, supported until early 2018.