### PR TITLE
Draft: Broaden support for php back to 7.1, downgrade phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 vendor/
-composer.lock
+composer*.lock
 composer.phar
 .DS_Store
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: php
 dist: xenial
 php:
+    - 7.1
+    - 7.2
     - 7.3
     - 7.4
 
 before_script:
     - composer install
 
-script: phpunit --verbose
+script: php ./vendor/bin/phpunit --verbose

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 
 - [Sign up](https://www.messagebird.com/en/signup) for a free MessageBird account
 - Create a new access_key in the developers sections
-- MessageBird API client for PHP requires PHP >= 5.4.
+- MessageBird API client for PHP requires PHP >= 7.1.
 
 Installation
 -----

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.1",
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently a draft, but can't use Github's draft PR feature because I want to trigger travis.