### PR TITLE
Bump version to 1.17.0.

### DIFF
--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -19,7 +19,7 @@ class Client
     const ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX = 'ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX';
     const CONVERSATIONSAPI_WHATSAPP_SANDBOX_ENDPOINT = 'https://whatsapp-sandbox.messagebird.com/v1';
 
-    const CLIENT_VERSION = '1.15.0';
+    const CLIENT_VERSION = '1.17.0';
 
     /**
      * @var string


### PR DESCRIPTION
It appears as if 1.16.x was skipped, but this is not the case; 1.16.0
and 1.16.1 were tagged and published to Packagist, but this was not
represented in the code