### PR TITLE
Add the Conversations API `/send` endpoint

### DIFF
--- a/examples/conversations/create-hsm.php
+++ b/examples/conversations/create-hsm.php
@@ -6,22 +6,24 @@ require(__DIR__ . '/../../autoload.php');
 
 $messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
 
-$content = new \MessageBird\Objects\Conversation\Content();
+$hsmParam1 = new \MessageBird\Objects\Conversation\HSM\Params();
+$hsmParam1->default = 'YOUR FIRST TEMPLATE PARAM VALUE';
 
-$hsm = new \MessageBird\Objects\Conversation\HSM\Message();
-
-$hsmParams = new \MessageBird\Objects\Conversation\HSM\Params();
-$hsmParams->default = 'YOUR TEMPLATE PARAM';
+$hsmParam2 = new \MessageBird\Objects\Conversation\HSM\Params();
+$hsmParam2->default = 'YOUR SECOND TEMPLATE PARAM VALUE';
 
 $hsmLanguage = new \MessageBird\Objects\Conversation\HSM\Language();
 $hsmLanguage->policy = \MessageBird\Objects\Conversation\HSM\Language::DETERMINISTIC_POLICY;
 //$hsmLanguage->policy = \MessageBird\Objects\Conversation\HSM\Language::FALLBACK_POLICY;
 $hsmLanguage->code = 'YOUR LANGUAGE CODE';
 
+$hsm = new \MessageBird\Objects\Conversation\HSM\Message();
 $hsm->templateName = 'YOUR TEMPLATE NAME';
 $hsm->namespace = 'YOUR NAMESPACE';
-$hsm->params = array($hsmParams);
+$hsm->params = array($hsmParam1, $hsmParam2);
 $hsm->language = $hsmLanguage;
+
+$content = new \MessageBird\Objects\Conversation\Content();
 $content->hsm = $hsm;
 
 $message = new \MessageBird\Objects\Conversation\Message();

--- a/examples/conversations/send.php
+++ b/examples/conversations/send.php
@@ -1,0 +1,26 @@
+<?php
+
+// Initiates a conversation by sending a first message, or adding a message to an already existing conversation with
+// the same contact as mentioned in "to". This example uses a plain text message, but other types are also available.
+// See the conversations-messages-create examples.
+
+require(__DIR__ . '/../../autoload.php');
+
+$messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API access key here.
+
+$content = new \MessageBird\Objects\Conversation\Content();
+$content->text = 'Hello world';
+
+$message = new \MessageBird\Objects\Conversation\SendMessage();
+$message->from = 'CHANNEL_ID';
+$message->to = 'RECIPIENT'; // Channel-specific, e.g. MSISDN for SMS.
+$message->content = $content;
+$message->type = 'text';
+
+try {
+    $sendMessage = $messageBird->conversationSend->send($message);
+
+    var_dump($sendMessage);
+} catch (\Exception $e) {
+    echo sprintf("%s: %s", get_class($e), $e->getMessage());
+}

--- a/examples/conversations/send.php
+++ b/examples/conversations/send.php
@@ -11,16 +11,16 @@ $messageBird = new \MessageBird\Client('YOUR_ACCESS_KEY'); // Set your own API a
 $content = new \MessageBird\Objects\Conversation\Content();
 $content->text = 'Hello world';
 
-$message = new \MessageBird\Objects\Conversation\SendMessage();
-$message->from = 'CHANNEL_ID';
-$message->to = 'RECIPIENT'; // Channel-specific, e.g. MSISDN for SMS.
-$message->content = $content;
-$message->type = 'text';
+$sendMessage = new \MessageBird\Objects\Conversation\SendMessage();
+$sendMessage->from = 'CHANNEL_ID';
+$sendMessage->to = 'RECIPIENT'; // Channel-specific, e.g. MSISDN for SMS.
+$sendMessage->content = $content;
+$sendMessage->type = 'text';
 
 try {
-    $sendMessage = $messageBird->conversationSend->send($message);
+    $sendResult = $messageBird->conversationSend->send($sendMessage);
 
-    var_dump($sendMessage);
+    var_dump($sendResult);
 } catch (\Exception $e) {
     echo sprintf("%s: %s", get_class($e), $e->getMessage());
 }

--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -67,11 +67,6 @@ class Client
     public $lookup;
 
     /**
-     * @var Resources\AvailableNumbers
-     */
-    public $availableNumbers;
-
-    /**
      * @var Resources\LookupHlr
      */
     public $lookupHlr;
@@ -150,6 +145,11 @@ class Client
      * @var Resources\Conversation\Messages;
      */
     public $conversationMessages;
+
+    /**
+     * @var Resources\Conversation\Send;
+     */
+    public $conversationSend;
 
     /**
      * @var Resources\Conversation\Webhooks;
@@ -254,6 +254,7 @@ class Client
         $this->groups = new Resources\Groups($this->HttpClient);
         $this->conversations = new Resources\Conversation\Conversations($this->ConversationsAPIHttpClient);
         $this->conversationMessages = new Resources\Conversation\Messages($this->ConversationsAPIHttpClient);
+        $this->conversationSend = new Resources\Conversation\Send($this->ConversationsAPIHttpClient);
         $this->conversationWebhooks = new Resources\Conversation\Webhooks($this->ConversationsAPIHttpClient);
         $this->partnerAccounts = new Resources\PartnerAccount\Accounts($this->partnerAccountClient);
         $this->phoneNumbers = new Resources\PhoneNumbers($this->numbersAPIClient);

--- a/src/MessageBird/Client.php
+++ b/src/MessageBird/Client.php
@@ -19,7 +19,7 @@ class Client
     const ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX = 'ENABLE_CONVERSATIONSAPI_WHATSAPP_SANDBOX';
     const CONVERSATIONSAPI_WHATSAPP_SANDBOX_ENDPOINT = 'https://whatsapp-sandbox.messagebird.com/v1';
 
-    const CLIENT_VERSION = '1.17.0';
+    const CLIENT_VERSION = '1.18.0';
 
     /**
      * @var string

--- a/src/MessageBird/Objects/Conversation/Fallback.php
+++ b/src/MessageBird/Objects/Conversation/Fallback.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MessageBird\Objects\Conversation;
+
+class Fallback
+{
+    /**
+     * The ID that identifies the channel over which the message should be sent.
+     *
+     * @var string
+     */
+    public $from;
+
+    /**
+     * This is optional. You can set a time period before attempting to send the fallback.
+     * After this time, if the original message isn't in a successfully delivered state, the fallback will be triggered.
+     * Formatted as a short-hand duration, for example: "30m" for 30 minutes, "3h" for 3 hours. If the fallback time
+     * period isn't specified, 1 minute will be used as the default value.
+     *
+     * @var string
+     */
+    public $after;
+}

--- a/src/MessageBird/Objects/Conversation/SendMessage.php
+++ b/src/MessageBird/Objects/Conversation/SendMessage.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MessageBird\Objects\Conversation;
+
+use JsonSerializable;
+use MessageBird\Objects\Base;
+
+/**
+ * Message that is send via the /send endpoint of the Conversations API
+ */
+class SendMessage extends Base implements JsonSerializable
+{
+    /**
+     * Either a channel-specific identifier for the receiver (e.g. MSISDN for SMS or WhatsApp channels),
+     * or the ID of a MessageBird Contact.
+     * 
+     * @var string
+     */
+    public $to;
+
+    /**
+     * The ID that identifies the channel over which the message should be sent.
+     * 
+     * @var string
+     */
+    public $from;
+
+    /**
+     * Type of this message's content. Possible values: "text", "image",
+     * "audio", "video", "file", "location".
+     * 
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Content of the message. Implementation dependent on this message's type.
+     * 
+     * @var Content
+     */
+    public $content;
+
+    /**
+     * The URL for delivery of status reports for the message. Must be HTTPS.
+     *
+     * @var string
+     */
+    public $reportUrl;
+
+    /**
+     * The additional settings to send a Fallback message if the primary delivery fails
+     *
+     * @var Fallback
+     */
+    public $fallback;
+
+    /**
+     * The source of the response/action that sent the message.
+     * 
+     * @var \stdClass
+     */
+    public $source;
+
+    /**
+     * Mark the message with a particular MessageBird Message Tag. The meaning and effect of each tag depend on each
+     * specific platform.
+     *
+     * @var string
+     */
+    public $tag;
+
+    /**
+     * Serialize only non empty fields.
+     */
+    public function jsonSerialize()
+    {
+        $json = array();
+        
+        foreach (get_object_vars($this) as $key => $value) {
+            if (!empty($value)) {
+                $json[$key] = $value;
+            }
+        }
+
+        return $json;
+    }
+}

--- a/src/MessageBird/Objects/Conversation/SendMessageResult.php
+++ b/src/MessageBird/Objects/Conversation/SendMessageResult.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MessageBird\Objects\Conversation;
+
+use JsonSerializable;
+use MessageBird\Objects\Base;
+
+class SendMessageResult extends Base implements JsonSerializable
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $status;
+
+    /**
+     * Serialize only non empty fields.
+     */
+    public function jsonSerialize()
+    {
+        $json = array();
+
+        foreach (get_object_vars($this) as $key => $value) {
+            if (!empty($value)) {
+                $json[$key] = $value;
+            }
+        }
+
+        return $json;
+    }
+}

--- a/src/MessageBird/Resources/Conversation/Conversations.php
+++ b/src/MessageBird/Resources/Conversation/Conversations.php
@@ -3,6 +3,7 @@
 namespace MessageBird\Resources\Conversation;
 
 use MessageBird\Common\HttpClient;
+use MessageBird\Exceptions;
 use MessageBird\Objects\Conversation\Conversation;
 use MessageBird\Objects\Conversation\Message;
 use MessageBird\Resources\Base;
@@ -25,7 +26,7 @@ class Conversations extends Base
      * @param Message $object
      * @param array|null $query
      *
-     * @return Message
+     * @return Conversation
      * 
      * @throws Exceptions\HttpException
      * @throws Exceptions\RequestException
@@ -58,7 +59,7 @@ class Conversations extends Base
      * 
      * @param int $contactId
      * 
-     * @return Message
+     * @return Conversation
      * 
      * @throws Exceptions\HttpException
      * @throws Exceptions\RequestException

--- a/src/MessageBird/Resources/Conversation/Send.php
+++ b/src/MessageBird/Resources/Conversation/Send.php
@@ -10,7 +10,7 @@ use MessageBird\Resources\Base;
 
 class Send extends Base
 {
-    const RESOURCE_NAME = 'conversations/send';
+    const RESOURCE_NAME = 'send';
 
     public function __construct(HttpClient $httpClient)
     {
@@ -36,13 +36,13 @@ class Send extends Base
     {
         $body = json_encode($object);
 
-        list(, , $body) = $this->HttpClient->performHttpRequest(
+        list(, , $resultBody) = $this->HttpClient->performHttpRequest(
             HttpClient::REQUEST_POST,
             $this->getResourceName(),
             $query,
             $body
         );
 
-        return $this->processRequest($body);
+        return $this->processRequest($resultBody);
     }
 }

--- a/src/MessageBird/Resources/Conversation/Send.php
+++ b/src/MessageBird/Resources/Conversation/Send.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MessageBird\Resources\Conversation;
+
+use MessageBird\Common\HttpClient;
+use MessageBird\Exceptions;
+use MessageBird\Objects\Conversation\SendMessage;
+use MessageBird\Objects\Conversation\SendMessageResult;
+use MessageBird\Resources\Base;
+
+class Send extends Base
+{
+    const RESOURCE_NAME = 'conversations/send';
+
+    public function __construct(HttpClient $httpClient)
+    {
+        parent::__construct($httpClient);
+
+        $this->setObject(new SendMessageResult());
+        $this->setResourceName(self::RESOURCE_NAME);
+    }
+
+    /**
+     * Starts a conversation or adding a message to the conversation when a conversation with the contact already exist.
+     *
+     * @param SendMessage $object
+     * @param array|null $query
+     *
+     * @return SendMessageResult
+     *
+     * @throws Exceptions\HttpException
+     * @throws Exceptions\RequestException
+     * @throws Exceptions\ServerException
+     */
+    public function send($object, $query = null)
+    {
+        $body = json_encode($object);
+
+        list(, , $body) = $this->HttpClient->performHttpRequest(
+            HttpClient::REQUEST_POST,
+            $this->getResourceName(),
+            $query,
+            $body
+        );
+
+        return $this->processRequest($body);
+    }
+}


### PR DESCRIPTION
Adding functionality for the `/send` endpoint of the Conversations API. 

Following the following documentation: https://developers.messagebird.com/api/conversations/#send-message