### PR TITLE
Enforce assertion consistency.

### DIFF
--- a/tests/integration/mms/MmsTest.php
+++ b/tests/integration/mms/MmsTest.php
@@ -56,7 +56,7 @@ class MmsTest extends BaseTest
         $this->assertAttributeEquals(1, 'count', $ResultMessages);
         $this->assertAttributeEquals(2, 'totalCount', $ResultMessages);
 
-        $this->assertEquals(2, count($ResultMessages->items));
+        $this->assertCount(2, $ResultMessages->items);
         $this->assertMessagesAreEqual($dummyMessage, $ResultMessages->items[0], 'message_id');
         $this->assertMessagesAreEqual($dummyMessage, $ResultMessages->items[1], 'message_id_2');
 

--- a/tests/unit/RequestValidatorTest.php
+++ b/tests/unit/RequestValidatorTest.php
@@ -24,7 +24,7 @@ class RequestValidatorTest extends TestCase
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
         $validator = new RequestValidator('PlLrKaqvZNRR5zAjm42ZT6q1SQxgbbGd');
 
-        self::assertTrue($validator->verify($request));
+        $this->assertTrue($validator->verify($request));
     }
 
     public function testVerifyWithBody()
@@ -45,7 +45,7 @@ class RequestValidatorTest extends TestCase
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
         $validator = new RequestValidator('PlLrKaqvZNRR5zAjm42ZT6q1SQxgbbGd');
 
-        self::assertTrue($validator->verify($request));
+        $this->assertTrue($validator->verify($request));
     }
 
     public function testVerificationFails()
@@ -66,7 +66,7 @@ class RequestValidatorTest extends TestCase
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
         $validator = new RequestValidator('PlLrKaqvZNRR5zAjm42ZT6q1SQxgbbGd');
 
-        self::assertFalse($validator->verify($request));
+        $this->assertFalse($validator->verify($request));
     }
 
     public function testRecentRequest()
@@ -79,7 +79,7 @@ class RequestValidatorTest extends TestCase
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
         $validator = new RequestValidator('');
 
-        self::assertTrue($validator->isRecent($request));
+        $this->assertTrue($validator->isRecent($request));
     }
 
     public function testExpiredRequest()
@@ -92,6 +92,6 @@ class RequestValidatorTest extends TestCase
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
         $validator = new RequestValidator('');
 
-        self::assertFalse($validator->isRecent($request));
+        $this->assertFalse($validator->isRecent($request));
     }
 }

--- a/tests/unit/SignedRequestTest.php
+++ b/tests/unit/SignedRequestTest.php
@@ -22,10 +22,10 @@ class SignedRequestTest extends TestCase
 
         $request = SignedRequest::create($query, $signature, $requestTimestamp, $body);
 
-        self::assertEquals($requestTimestamp, $request->requestTimestamp);
-        self::assertEquals($body, $request->body);
-        self::assertEquals($query, $request->queryParameters);
-        self::assertEquals($signature, $request->signature);
+        $this->assertEquals($requestTimestamp, $request->requestTimestamp);
+        $this->assertEquals($body, $request->body);
+        $this->assertEquals($query, $request->queryParameters);
+        $this->assertEquals($signature, $request->signature);
     }
 
     public function testLoadFromArray()
@@ -51,10 +51,10 @@ class SignedRequestTest extends TestCase
             'body' => $body
         ));
 
-        self::assertEquals($requestTimestamp, $request->requestTimestamp);
-        self::assertEquals($body, $request->body);
-        self::assertEquals($query, $request->queryParameters);
-        self::assertEquals($signature, $request->signature);
+        $this->assertEquals($requestTimestamp, $request->requestTimestamp);
+        $this->assertEquals($body, $request->body);
+        $this->assertEquals($query, $request->queryParameters);
+        $this->assertEquals($signature, $request->signature);
     }
 
     public function testLoadInvalidQuery()


### PR DESCRIPTION
This PR enforces assertion consistency:
- use the more widely used non-static call.
- use `assertCount` when expected.