### PR TITLE
Use the null coalescing operator when possible.

### DIFF
--- a/src/MessageBird/Common/HttpClient.php
+++ b/src/MessageBird/Common/HttpClient.php
@@ -143,7 +143,7 @@ class HttpClient
      */
     public function getHttpOption($option)
     {
-        return isset($this->httpOptions[$option]) ? $this->httpOptions[$option] : null;
+        return $this->httpOptions[$option] ?? null;
     }
 
     /**

--- a/src/MessageBird/Objects/SignedRequest.php
+++ b/src/MessageBird/Objects/SignedRequest.php
@@ -53,8 +53,7 @@ class SignedRequest extends Base
         $queryParameters = $_GET;
         $requestTimestamp = isset($_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP']) ?
             (int)$_SERVER['HTTP_MESSAGEBIRD_REQUEST_TIMESTAMP'] : null;
-        $signature = isset($_SERVER['HTTP_MESSAGEBIRD_SIGNATURE']) ?
-            $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE'] : null;
+        $signature = $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE'] ?? null;
 
         $signedRequest = new SignedRequest();
         $signedRequest->loadFromArray(compact('body', 'queryParameters', 'requestTimestamp', 'signature'));


### PR DESCRIPTION
Simplify some parts of the code by using the null coalescing operator when possible.