### PR TITLE
Remove useless tests code.

### DIFF
--- a/tests/Integration/Balance/BalanceTest.php
+++ b/tests/Integration/Balance/BalanceTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class BalanceTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testReadBalance()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/BaseTest.php
+++ b/tests/Integration/BaseTest.php
@@ -14,6 +14,8 @@ class BaseTest extends TestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->mockClient = $this->getMockBuilder("\MessageBird\Common\HttpClient")->setConstructorArgs(["fake.messagebird.dev"])->getMock();
         $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
     }

--- a/tests/Integration/Chat/ChatTest.php
+++ b/tests/Integration/Chat/ChatTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class ChatTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateChatMessage()
     {
         $ChatMessage = new \MessageBird\Objects\Chat\Message();

--- a/tests/Integration/Contacts/ContactTest.php
+++ b/tests/Integration/Contacts/ContactTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class ContactTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateContact()
     {
         $Contact             = new \MessageBird\Objects\Contact();

--- a/tests/Integration/Conversation/ConversationMessageTest.php
+++ b/tests/Integration/Conversation/ConversationMessageTest.php
@@ -49,13 +49,6 @@ class ConversationMessageTest extends BaseTest
         "type": "video"
     }';
 
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->client = new Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateImage()
     {
         $this->mockClient

--- a/tests/Integration/Conversation/ConversationTest.php
+++ b/tests/Integration/Conversation/ConversationTest.php
@@ -97,13 +97,6 @@ class ConversationTest extends BaseTest
         "lastUsedChannelId": "channel-id"
     }';
 
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->client = new Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testStart()
     {
         $this->mockClient
@@ -122,7 +115,7 @@ class ConversationTest extends BaseTest
         $message->to = '31612345678';
         $message->type = 'location';
         $message->content = $content;
-        
+
         $this->client->conversations->start($message);
     }
 
@@ -135,10 +128,10 @@ class ConversationTest extends BaseTest
             ->expects($this->once())->method('performHttpRequest')
             ->with('POST', 'conversations', null, self::CREATE_REQUEST)
             ->willReturn([200, '', '{}']);
-        
+
         $this->client->conversations->create('some-contact-id');
     }
-    
+
     public function testList()
     {
         $this->mockClient
@@ -178,12 +171,12 @@ class ConversationTest extends BaseTest
             ->expects($this->exactly(2))->method('performHttpRequest')
             ->withConsecutive(
                 ['PATCH', 'conversations/conversation-id', null, '{"status":"archived"}'],
-                ['PATCH', 'conversations/conversation-id', null, '{"status":"active"}']                
+                ['PATCH', 'conversations/conversation-id', null, '{"status":"active"}']
             )
             ->willReturn([200, '', '{}']);
 
         $conversation = new Conversation();
-        
+
         $conversation->status = Conversation::STATUS_ARCHIVED;
         $this->client->conversations->update($conversation, 'conversation-id');
 

--- a/tests/Integration/Conversation/ConversationWebhookTest.php
+++ b/tests/Integration/Conversation/ConversationWebhookTest.php
@@ -40,13 +40,6 @@ class ConversationWebhookTest extends BaseTest
         "updatedDatetime": "2018-07-20T12:13:51+00:00"
     }';
 
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testDelete()
     {
         $this->mockClient

--- a/tests/Integration/Groups/GroupTest.php
+++ b/tests/Integration/Groups/GroupTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class GroupTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateGroup()
     {
         $Group             = new \MessageBird\Objects\Group();

--- a/tests/Integration/Hlr/HlrTest.php
+++ b/tests/Integration/Hlr/HlrTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class HlrTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateHlr()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/Lookup/LookupTest.php
+++ b/tests/Integration/Lookup/LookupTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class LookupTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testReadLookup()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/Messages/MessagesTest.php
+++ b/tests/Integration/Messages/MessagesTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class MessageTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateMessage()
     {
         $Message             = new \MessageBird\Objects\Message();

--- a/tests/Integration/Numbers/AvailablePhoneNumbersTest.php
+++ b/tests/Integration/Numbers/AvailablePhoneNumbersTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class AvailablePhoneNumbersTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testListAvailablePhoneNumbers()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/Numbers/PhoneNumbersTest.php
+++ b/tests/Integration/Numbers/PhoneNumbersTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class PhoneNumbersTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testReadPhoneNumber()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/PartnerAccount/AccountTest.php
+++ b/tests/Integration/PartnerAccount/AccountTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class AccountTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testCreateSubAccount()
     {
         $account = new \MessageBird\Objects\PartnerAccount\Account();

--- a/tests/Integration/Verify/VerifyTest.php
+++ b/tests/Integration/Verify/VerifyTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class VerifyTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testGenerateOtp()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/Voice/VoiceTest.php
+++ b/tests/Integration/Voice/VoiceTest.php
@@ -6,15 +6,6 @@ use Tests\Integration\BaseTest;
 
 class VoiceTest extends BaseTest
 {
-    /** @var \MessageBird\Client client */
-    public $client;
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testListVoiceCall()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);

--- a/tests/Integration/VoiceMessages/VoiceMessagesTest.php
+++ b/tests/Integration/VoiceMessages/VoiceMessagesTest.php
@@ -6,12 +6,6 @@ use Tests\Integration\BaseTest;
 
 class VoiceMessagesTest extends BaseTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->client = new \MessageBird\Client('YOUR_ACCESS_KEY', $this->mockClient);
-    }
-
     public function testVoiceMessageCreate()
     {
         $this->expectException(\MessageBird\Exceptions\ServerException::class);


### PR DESCRIPTION
This PR removes useless code, as the client is already declared in `\Tests\Integration\BaseTest::setUp`

---

I guess at some point those tests would need larger cleanup/refactoring.

cc / @rfeiner @CoolGoose 