### PR TITLE
⬆️ Provide support for PHP 8.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '7.0','7.1','7.2','7.3', '7.4' ]
+        php: [ '7.3', '7.4','8.0' ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         "source": "https://github.com/messagebird/php-rest-api"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.3|^8.0",
         "ext-curl": "*",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.5"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/BaseTest.php
+++ b/tests/Integration/BaseTest.php
@@ -24,7 +24,7 @@ class BaseTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     protected $mockClient;
 
-    protected function setUp()
+    protected function setUp():void
     {
         parent::setUp();
 

--- a/tests/Integration/HttpClientTest.php
+++ b/tests/Integration/HttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration;
 
+use InvalidArgumentException;
 use MessageBird\Client;
 use MessageBird\Common\HttpClient;
 
@@ -20,8 +21,8 @@ class HttpClientTest extends BaseTest
 
     public function testHttpClientInvalidTimeout()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/^Timeout must be an int > 0, got "integer 0".$/');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Timeout must be an int > 0, got "integer 0"');
         new HttpClient(Client::ENDPOINT, 0);
     }
 
@@ -37,8 +38,8 @@ class HttpClientTest extends BaseTest
 
     public function testHttpClientInvalidConnectionTimeout()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/^Connection timeout must be an int >= 0, got "stdClass".$/');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Connection timeout must be an int >= 0, got "stdClass"');
         new HttpClient(Client::ENDPOINT, 10, new \stdClass());
     }
 
@@ -58,7 +59,7 @@ class HttpClientTest extends BaseTest
     public function testHttpClientWithoutAuthenticationException()
     {
         $this->expectException(\MessageBird\Exceptions\AuthenticateException::class);
-        $this->expectExceptionMessageRegExp('/Can not perform API Request without Authentication/');
+        $this->expectExceptionMessage('Can not perform API Request without Authentication');
         $client = new HttpClient(Client::ENDPOINT);
         $client->performHttpRequest('foo', 'bar');
     }

--- a/tests/Integration/Mms/MmsTest.php
+++ b/tests/Integration/Mms/MmsTest.php
@@ -57,9 +57,9 @@ class MmsTest extends BaseTest
 
         $resultMessages = $this->client->mmsMessages->getList(['offset' => 100, 'limit' => 30]);
 
-        $this->assertAttributeEquals(0, 'offset', $resultMessages);
-        $this->assertAttributeEquals(1, 'count', $resultMessages);
-        $this->assertAttributeEquals(2, 'totalCount', $resultMessages);
+        $this->assertSame(0, $resultMessages->offset);
+        $this->assertSame(1, $resultMessages->count);
+        $this->assertSame(2, $resultMessages->totalCount);
 
         $this->assertCount(2, $resultMessages->items);
         $this->assertMessagesAreEqual($dummyMessage, $resultMessages->items[0], 'message_id');
@@ -125,17 +125,17 @@ class MmsTest extends BaseTest
      */
     private function assertMessagesAreEqual(\MessageBird\Objects\MmsMessage $mmsMessage, \MessageBird\Objects\MmsMessage $resultMmsMessage, $expectedId)
     {
-        $this->assertAttributeEquals($expectedId, 'id', $resultMmsMessage);
-        $this->assertAttributeEquals("https://rest.messagebird.com/mms/{$expectedId}", 'href', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->direction, 'direction', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->originator, 'originator', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->subject, 'subject', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->body, 'body', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->mediaUrls, 'mediaUrls', $resultMmsMessage);
-        $this->assertAttributeEquals($mmsMessage->reference, 'reference', $resultMmsMessage);
+        $this->assertSame($expectedId, $resultMmsMessage->getId());
+        $this->assertSame("https://rest.messagebird.com/mms/{$expectedId}", $resultMmsMessage->getHref());
+        $this->assertSame($mmsMessage->direction, $resultMmsMessage->direction);
+        $this->assertSame($mmsMessage->originator, $resultMmsMessage->originator);
+        $this->assertSame($mmsMessage->subject, $resultMmsMessage->subject);
+        $this->assertSame($mmsMessage->body, $resultMmsMessage->body);
+        $this->assertSame($mmsMessage->mediaUrls, $resultMmsMessage->mediaUrls);
+        $this->assertSame($mmsMessage->reference, $resultMmsMessage->reference);
 
         foreach ($resultMmsMessage->recipients->items as $item) {
-            $this->assertArraySubset([$item->recipient], $mmsMessage->recipients);
+            $this->assertContains($item->recipient, $mmsMessage->recipients);
         }
     }
 


### PR DESCRIPTION
This PR provides much-needed support for PHP 8.

At the moment only PHP versions 7.0 to 7.4 are supported, which is not optimal for client adoption. Indeed, many projects already require PHP version 8 as a platform dependency.

Also, this PR drops support for version below 7.3. As planned within the supported [PHP versions timeline](https://www.php.net/supported-versions.php), the PHP 7.2 version does not receive security fixes since November 2020.

It is thus safe to deprecate the support of these versions.

---

**Note:** 

a new major release for this client will have to be published (on Github and Packagist)
/cc @bviolier @rfeiner @CoolGoose 