### PR TITLE
Deprecated loadFromArray for loadFromStdClass and fixed parsing of contacts in Groups::getContacts

### DIFF
--- a/src/MessageBird/Objects/Base.php
+++ b/src/MessageBird/Objects/Base.php
@@ -14,7 +14,7 @@ class Base
      *
      * @return $this
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         if ($object) {
             foreach ($object as $key => $value) {

--- a/src/MessageBird/Objects/Base.php
+++ b/src/MessageBird/Objects/Base.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Base
  *
@@ -10,17 +12,33 @@ namespace MessageBird\Objects;
 class Base
 {
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
-     * @return $this
+     * @return self
      */
-    public function loadFromArray($object): self
+    public function loadFromArray($object)
     {
         if ($object) {
             foreach ($object as $key => $value) {
                 if (property_exists($this, $key)) {
                     $this->$key = $value;
                 }
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * @param stdClass $object
+     * @return self
+     */
+    public function loadFromStdclass(stdClass $object)
+    {
+        foreach ($object as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
             }
         }
         return $this;

--- a/src/MessageBird/Objects/Contact.php
+++ b/src/MessageBird/Objects/Contact.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Contact
  *
@@ -65,16 +67,16 @@ class Contact extends Base
     /**
      * The hash of the group this contact belongs to.
      *
-     * @var array
+     * @var stdClass
      */
-    protected $groups = [];
+    protected $groups;
 
     /**
      * The hash with messages sent to contact.
      *
-     * @var array
+     * @var stdClass
      */
-    protected $messages = [];
+    protected $messages;
 
     /**
      * The date and time of the creation of the contact in RFC3339 format (Y-m-d\TH:i:sP)
@@ -100,12 +102,12 @@ class Contact extends Base
         return $this->href;
     }
 
-    public function getGroups(): array
+    public function getGroups(): stdClass
     {
         return $this->groups;
     }
 
-    public function getMessages(): array
+    public function getMessages(): stdClass
     {
         return $this->messages;
     }

--- a/src/MessageBird/Objects/Contact.php
+++ b/src/MessageBird/Objects/Contact.php
@@ -115,7 +115,7 @@ class Contact extends Base
         return $this->createdDatetime;
     }
 
-    public function getUpdatedDatetime(): string
+    public function getUpdatedDatetime(): ?string
     {
         return $this->updatedDatetime;
     }

--- a/src/MessageBird/Objects/Contact.php
+++ b/src/MessageBird/Objects/Contact.php
@@ -67,16 +67,16 @@ class Contact extends Base
     /**
      * The hash of the group this contact belongs to.
      *
-     * @var stdClass
+     * @var ?stdClass
      */
-    protected $groups;
+    protected $groups = null;
 
     /**
      * The hash with messages sent to contact.
      *
-     * @var stdClass
+     * @var ?stdClass
      */
-    protected $messages;
+    protected $messages = null;
 
     /**
      * The date and time of the creation of the contact in RFC3339 format (Y-m-d\TH:i:sP)
@@ -130,10 +130,10 @@ class Contact extends Base
     /**
      * @param mixed $object
      */
-    public function loadFromArray($object): Contact
+    public function loadFromArray($object): self
     {
         unset($this->custom1, $this->custom2, $this->custom3, $this->custom4);
-
+        
         return parent::loadFromArray($object);
     }
 

--- a/src/MessageBird/Objects/Contact.php
+++ b/src/MessageBird/Objects/Contact.php
@@ -128,6 +128,8 @@ class Contact extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      */
     public function loadFromArray($object): self
@@ -137,7 +139,16 @@ class Contact extends Base
         return parent::loadFromArray($object);
     }
 
+    public function loadFromStdclass(stdClass $object): self
+    {
+        unset($this->custom1, $this->custom2, $this->custom3, $this->custom4);
+        
+        return parent::loadFromStdclass($object);
+    }
+
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclassForGroups()}
+     * 
      * @param mixed $object
      *
      * @return $this ->object
@@ -150,6 +161,21 @@ class Contact extends Base
             foreach ($object->items as &$item) {
                 $group = new Group();
                 $group->loadFromArray($item);
+
+                $item = $group;
+            }
+        }
+        return $object;
+    }
+
+    public function loadFromStdclassForGroups(stdClass $object)
+    {
+        parent::loadFromStdclass($object);
+
+        if (!empty($object->items)) {
+            foreach ($object->items as &$item) {
+                $group = new Group();
+                $group->loadFromStdclass($item);
 
                 $item = $group;
             }

--- a/src/MessageBird/Objects/Conversation/Contact.php
+++ b/src/MessageBird/Objects/Conversation/Contact.php
@@ -3,6 +3,7 @@
 namespace MessageBird\Objects\Conversation;
 
 use MessageBird\Objects\Base;
+use stdClass;
 
 /**
  * Represents a counterparty with who messages can be exchanged.
@@ -65,11 +66,24 @@ class Contact extends Base
     public $updatedDatetime;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      */
     public function loadFromArray($object): Contact
     {
         parent::loadFromArray($object);
+
+        if (!empty($this->customDetails)) {
+            $this->customDetails = (array)$this->customDetails;
+        }
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
 
         if (!empty($this->customDetails)) {
             $this->customDetails = (array)$this->customDetails;

--- a/src/MessageBird/Objects/Conversation/Content.php
+++ b/src/MessageBird/Objects/Conversation/Content.php
@@ -59,7 +59,7 @@ class Content extends Base implements JsonSerializable
      *
      * @return $this
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         // Text is already properly set if available due to the response's structure.
         parent::loadFromArray($object);

--- a/src/MessageBird/Objects/Conversation/Content.php
+++ b/src/MessageBird/Objects/Conversation/Content.php
@@ -5,6 +5,7 @@ namespace MessageBird\Objects\Conversation;
 use JsonSerializable;
 use MessageBird\Objects\Base;
 use MessageBird\Objects\Conversation\HSM\Message as HSMMessage;
+use stdClass;
 
 /**
  * Represents a Message object's actual content. Formatted depending on type.
@@ -55,6 +56,8 @@ class Content extends Base implements JsonSerializable
     public $hsm;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
      * @return $this
@@ -63,6 +66,17 @@ class Content extends Base implements JsonSerializable
     {
         // Text is already properly set if available due to the response's structure.
         parent::loadFromArray($object);
+
+        $this->loadLocationIfNeeded();
+        $this->loadMediaIfNeeded();
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        // Text is already properly set if available due to the response's structure.
+        parent::loadFromStdclass($object);
 
         $this->loadLocationIfNeeded();
         $this->loadMediaIfNeeded();

--- a/src/MessageBird/Objects/Conversation/Conversation.php
+++ b/src/MessageBird/Objects/Conversation/Conversation.php
@@ -3,6 +3,7 @@
 namespace MessageBird\Objects\Conversation;
 
 use MessageBird\Objects\Base;
+use stdClass;
 
 /**
  * A conversation is the view of all messages between you and a customer across
@@ -96,6 +97,8 @@ class Conversation extends Base
     public $updatedDatetime;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      */
     public function loadFromArray($object): Conversation
@@ -125,6 +128,40 @@ class Conversation extends Base
         if (!empty($this->messages)) {
             $messages = new MessageReference();
             $messages->loadFromArray($this->messages);
+
+            $this->messages = $messages;
+        }
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        if (!empty($object->contact)) {
+            $newContact = new Contact();
+            $newContact->loadFromStdclass($object->contact);
+
+            $this->contact = $newContact;
+        }
+
+        if (!empty($object->channels)) {
+            $channels = [];
+
+            foreach ($object->channels as $channel) {
+                $newChannel = new Channel();
+                $newChannel->loadFromStdclass($channel);
+
+                $channels[] = $newChannel;
+            }
+
+            $this->channels = $channels;
+        }
+
+        if (!empty($object->messages)) {
+            $messages = new MessageReference();
+            $messages->loadFromStdclass($object->messages);
 
             $this->messages = $messages;
         }

--- a/src/MessageBird/Objects/Conversation/Message.php
+++ b/src/MessageBird/Objects/Conversation/Message.php
@@ -4,6 +4,7 @@ namespace MessageBird\Objects\Conversation;
 
 use JsonSerializable;
 use MessageBird\Objects\Base;
+use stdClass;
 
 /**
  * Messages that have been sent by, or received from, a customer are
@@ -95,6 +96,8 @@ class Message extends Base implements JsonSerializable
     public $updatedDatetime;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      */
     public function loadFromArray($object): Message
@@ -105,6 +108,19 @@ class Message extends Base implements JsonSerializable
         $content->loadFromArray($this->content);
 
         $this->content = $content;
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        if (property_exists($object, 'content')) {
+            $content = new Content();
+            $content->loadFromStdclass($object->content);
+            $this->content = $content;
+        }
 
         return $this;
     }

--- a/src/MessageBird/Objects/Group.php
+++ b/src/MessageBird/Objects/Group.php
@@ -81,7 +81,7 @@ class Group extends Base
     /**
      * Get the $updatedDatetime value
      */
-    public function getUpdatedDatetime(): string
+    public function getUpdatedDatetime(): ?string
     {
         return $this->createdDatetime;
     }

--- a/src/MessageBird/Objects/Group.php
+++ b/src/MessageBird/Objects/Group.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Group
  *
@@ -15,6 +17,7 @@ class Group extends Base
      * @var int
      */
     public $name;
+
     /**
      * An unique random ID which is created on the MessageBird
      * platform and is returned upon creation of the object.
@@ -22,16 +25,18 @@ class Group extends Base
      * @var string
      */
     protected $id;
+
     /**
      * The URL of the created object.
      *
      * @var string
      */
     protected $href;
+
     /**
      * The hash with the contacts in group.
      *
-     * @var array
+     * @var stdClass
      */
     protected $contacts = [];
 
@@ -79,6 +84,11 @@ class Group extends Base
     public function getUpdatedDatetime(): string
     {
         return $this->createdDatetime;
+    }
+
+    public function getContacts(): stdClass
+    {
+        return $this->contacts;
     }
 
     /**

--- a/src/MessageBird/Objects/Group.php
+++ b/src/MessageBird/Objects/Group.php
@@ -36,9 +36,9 @@ class Group extends Base
     /**
      * The hash with the contacts in group.
      *
-     * @var stdClass
+     * @var ?stdClass
      */
-    protected $contacts = [];
+    protected $contacts = null;
 
     /**
      * The date and time of the creation of the group in RFC3339 format (Y-m-d\TH:i:sP)
@@ -99,15 +99,6 @@ class Group extends Base
     public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
-
-        if (!empty($object->items)) {
-            foreach ($object->items as &$item) {
-                $contact = new Contact();
-                $contact->loadFromArray($item);
-
-                $item = $contact;
-            }
-        }
 
         return $this;
     }

--- a/src/MessageBird/Objects/Group.php
+++ b/src/MessageBird/Objects/Group.php
@@ -86,7 +86,7 @@ class Group extends Base
      *
      * @return $this|void
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 
@@ -99,6 +99,6 @@ class Group extends Base
             }
         }
 
-        return $object;
+        return $this;
     }
 }

--- a/src/MessageBird/Objects/Group.php
+++ b/src/MessageBird/Objects/Group.php
@@ -92,14 +92,19 @@ class Group extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
      * @return $this|void
      */
     public function loadFromArray($object): self
     {
-        parent::loadFromArray($object);
+        return parent::loadFromArray($object);
+    }
 
-        return $this;
+    public function loadFromStdclass(stdClass $object): self
+    {
+        return parent::loadFromStdclass($object);
     }
 }

--- a/src/MessageBird/Objects/Lookup.php
+++ b/src/MessageBird/Objects/Lookup.php
@@ -121,7 +121,7 @@ class Lookup extends Base
      *
      * @return $this
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         unset($this->hlr);
         return parent::loadFromArray($object);

--- a/src/MessageBird/Objects/Lookup.php
+++ b/src/MessageBird/Objects/Lookup.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Lookup
  *
@@ -117,6 +119,8 @@ class Lookup extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
      * @return $this
@@ -125,5 +129,11 @@ class Lookup extends Base
     {
         unset($this->hlr);
         return parent::loadFromArray($object);
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        unset($this->hlr);
+        return parent::loadFromStdclass($object);
     }
 }

--- a/src/MessageBird/Objects/Message.php
+++ b/src/MessageBird/Objects/Message.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Message
  *
@@ -151,9 +153,13 @@ class Message extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
+     * 
+     * @return self
      */
-    public function loadFromArray($object): Message
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 
@@ -161,6 +167,26 @@ class Message extends Base
             foreach ($this->recipients->items as &$item) {
                 $recipient = new Recipient();
                 $recipient->loadFromArray($item);
+
+                $item = $recipient;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param stdClass $object 
+     * @return self 
+     */
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        if (!empty($this->recipients->items)) {
+            foreach ($this->recipients->items as &$item) {
+                $recipient = new Recipient();
+                $recipient->loadFromStdclass($item);
 
                 $item = $recipient;
             }

--- a/src/MessageBird/Objects/MessageResponse.php
+++ b/src/MessageBird/Objects/MessageResponse.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Message
  *
@@ -125,6 +127,8 @@ class MessageResponse extends Base
     public $recipients;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      */
     public function loadFromArray($object): MessageResponse
@@ -132,6 +136,16 @@ class MessageResponse extends Base
         parent::loadFromArray($object);
 
         $this->recipients = (new Recipients())->loadFromArray($this->recipients);
+        $this->typeDetails = get_object_vars($this->typeDetails);
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        $this->recipients = (new Recipients())->loadFromStdclass($this->recipients);
         $this->typeDetails = get_object_vars($this->typeDetails);
 
         return $this;

--- a/src/MessageBird/Objects/MmsMessage.php
+++ b/src/MessageBird/Objects/MmsMessage.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class MmsMessage
  *
@@ -106,6 +108,8 @@ class MmsMessage extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
      * @return $this|void
@@ -118,6 +122,22 @@ class MmsMessage extends Base
             foreach ($this->recipients->items as &$item) {
                 $recipient = new Recipient();
                 $recipient->loadFromArray($item);
+
+                $item = $recipient;
+            }
+        }
+
+        return $this;
+    }
+    
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        if (!empty($this->recipients->items)) {
+            foreach ($this->recipients->items as &$item) {
+                $recipient = new Recipient();
+                $recipient->loadFromStdclass($item);
 
                 $item = $recipient;
             }

--- a/src/MessageBird/Objects/MmsMessage.php
+++ b/src/MessageBird/Objects/MmsMessage.php
@@ -110,7 +110,7 @@ class MmsMessage extends Base
      *
      * @return $this|void
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 

--- a/src/MessageBird/Objects/Recipients.php
+++ b/src/MessageBird/Objects/Recipients.php
@@ -2,6 +2,8 @@
 
 namespace MessageBird\Objects;
 
+use stdClass;
+
 /**
  * Class Recipients
  *
@@ -35,6 +37,8 @@ class Recipients extends Base
     public $items;
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param $object
      *
      * @return $this|void
@@ -46,6 +50,20 @@ class Recipients extends Base
         foreach ($this->items as &$item) {
             $recipient = new Recipient();
             $recipient->loadFromArray($item);
+
+            $item = $recipient;
+        }
+
+        return $this;
+    }
+
+    public function loadFromStdclass(stdClass $object): self
+    {
+        parent::loadFromStdclass($object);
+
+        foreach ($this->items as &$item) {
+            $recipient = new Recipient();
+            $recipient->loadFromStdclass($item);
 
             $item = $recipient;
         }

--- a/src/MessageBird/Objects/Recipients.php
+++ b/src/MessageBird/Objects/Recipients.php
@@ -39,7 +39,7 @@ class Recipients extends Base
      *
      * @return $this|void
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 

--- a/src/MessageBird/Objects/SignedRequest.php
+++ b/src/MessageBird/Objects/SignedRequest.php
@@ -93,7 +93,7 @@ class SignedRequest extends Base
      * {@inheritdoc}
      * @throws ValidationException when a required parameter is missing.
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         if (!isset($object['requestTimestamp']) || !\is_int($object['requestTimestamp'])) {
             throw new ValidationException('The "requestTimestamp" value is missing or invalid.');

--- a/src/MessageBird/Objects/Voice/Call.php
+++ b/src/MessageBird/Objects/Voice/Call.php
@@ -68,7 +68,7 @@ class Call extends Base
     /**
      * @inheritdoc
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 

--- a/src/MessageBird/Objects/Voice/CallFlow.php
+++ b/src/MessageBird/Objects/Voice/CallFlow.php
@@ -44,7 +44,7 @@ class CallFlow extends Base
     /**
      * @inheritdoc
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 

--- a/src/MessageBird/Objects/VoiceMessage.php
+++ b/src/MessageBird/Objects/VoiceMessage.php
@@ -130,6 +130,8 @@ class VoiceMessage extends Base
     }
 
     /**
+     * @deprecated 2.2.0 No longer used by internal code, please switch to {@see self::loadFromStdclass()}
+     * 
      * @param mixed $object
      *
      * @return $this|void

--- a/src/MessageBird/Objects/VoiceMessage.php
+++ b/src/MessageBird/Objects/VoiceMessage.php
@@ -134,7 +134,7 @@ class VoiceMessage extends Base
      *
      * @return $this|void
      */
-    public function loadFromArray($object)
+    public function loadFromArray($object): self
     {
         parent::loadFromArray($object);
 

--- a/src/MessageBird/Resources/AvailablePhoneNumbers.php
+++ b/src/MessageBird/Resources/AvailablePhoneNumbers.php
@@ -51,11 +51,11 @@ class AvailablePhoneNumbers
         unset($body->items);
 
         $baseList = new Objects\BaseList();
-        $baseList->loadFromArray($body);
+        $baseList->loadFromStdclass($body);
 
         foreach ($items as $item) {
             $object = new Objects\Number();
-            $itemObject = $object->loadFromArray($item);
+            $itemObject = $object->loadFromStdclass($item);
             $baseList->items[] = $itemObject;
         }
         return $baseList;
@@ -80,6 +80,6 @@ class AvailablePhoneNumbers
             throw new Exceptions\RequestException($responseError->getErrorString());
         }
 
-        return (new Objects\Number())->loadFromArray($body->data[0]);
+        return (new Objects\Number())->loadFromStdclass($body->data[0]);
     }
 }

--- a/src/MessageBird/Resources/Balance.php
+++ b/src/MessageBird/Resources/Balance.php
@@ -14,7 +14,7 @@ class Balance extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Balance());
+        $this->object = new Objects\Balance();
         $this->setResourceName('balance');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Base.php
+++ b/src/MessageBird/Resources/Base.php
@@ -61,6 +61,8 @@ class Base
     }
 
     /**
+     * @deprecated
+     * 
      * @param mixed $object
      */
     public function setObject($object): void
@@ -133,10 +135,18 @@ class Base
         }
 
         if ($this->responseObject) {
-            return $this->responseObject->loadFromArray($body);
+            return $this->responseObject->loadFromStdclass($body);
+        }
+        
+        if (is_array($body)) {
+            $parsed = [];
+            foreach ($body as $b) {
+                $parsed[] = $this->object->loadFromStdclass($b);
+            }
+            return $parsed;
         }
 
-        return $this->object->loadFromArray($body);
+        return $this->object->loadFromStdclass($body);
     }
 
     /**

--- a/src/MessageBird/Resources/Contacts.php
+++ b/src/MessageBird/Resources/Contacts.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use MessageBird\Common;
 use MessageBird\Exceptions;
 use MessageBird\Objects;
+use MessageBird\Resources\Messages;
 
 /**
  * Class Contacts
@@ -14,10 +15,17 @@ use MessageBird\Objects;
  */
 class Contacts extends Base
 {
+    /**
+     * @var Messages
+     */
+    private $messagesObject;
+
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Contact());
+        $this->object = new Objects\Contact();
         $this->setResourceName('contacts');
+
+        $this->messagesObject = new Messages($httpClient);
 
         parent::__construct($httpClient);
     }
@@ -71,9 +79,8 @@ class Contacts extends Base
             throw new InvalidArgumentException('No contact id provided.');
         }
 
-        $this->setObject(new Objects\Message());
-        $this->setResourceName($this->resourceName . '/' . $id . '/messages');
-        return $this->getList($parameters);
+        $this->messagesObject->setResourceName($this->resourceName . '/' . $id . '/messages');
+        return $this->messagesObject->getList($parameters);
     }
 
     /**
@@ -89,7 +96,7 @@ class Contacts extends Base
             throw new InvalidArgumentException('No contact id provided.');
         }
 
-        $this->setObject(new Objects\Group());
+        $this->object = new Objects\Group();
         $this->setResourceName($this->resourceName . '/' . $id . '/groups');
         return $this->getList($parameters);
     }

--- a/src/MessageBird/Resources/Conversation/Contacts.php
+++ b/src/MessageBird/Resources/Conversation/Contacts.php
@@ -12,6 +12,6 @@ class Contacts extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new Contact());
+        $this->object = new Contact();
     }
 }

--- a/src/MessageBird/Resources/Conversation/Content.php
+++ b/src/MessageBird/Resources/Conversation/Content.php
@@ -12,6 +12,6 @@ class Content extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new ContentObject());
+        $this->object = new ContentObject();
     }
 }

--- a/src/MessageBird/Resources/Conversation/Conversations.php
+++ b/src/MessageBird/Resources/Conversation/Conversations.php
@@ -21,7 +21,7 @@ class Conversations extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new Conversation());
+        $this->object = new Conversation();
         $this->setResourceName(self::RESOURCE_NAME);
     }
 

--- a/src/MessageBird/Resources/Conversation/Messages.php
+++ b/src/MessageBird/Resources/Conversation/Messages.php
@@ -37,7 +37,7 @@ class Messages
     {
         $this->httpClient = $httpClient;
 
-        $this->setObject(new Message());
+        $this->object = new Message();
     }
 
     public function getObject(): Message
@@ -45,6 +45,12 @@ class Messages
         return $this->object;
     }
 
+    /**
+     * @deprecated
+     * 
+     * @param Message $object 
+     * @return void 
+     */
     public function setObject(Message $object): void
     {
         $this->object = $object;
@@ -104,7 +110,7 @@ class Messages
         }
 
         if (empty($body->errors)) {
-            return $this->object->loadFromArray($body);
+            return $this->object->loadFromStdclass($body);
         }
 
         $responseError = new ResponseError($body);
@@ -144,14 +150,14 @@ class Messages
             unset($body->items);
 
             $baseList = new BaseList();
-            $baseList->loadFromArray($body);
+            $baseList->loadFromStdclass($body);
 
             $objectName = $this->object;
 
             foreach ($items as $item) {
                 /** @psalm-suppress UndefinedClass */
                 $message = new $objectName($this->httpClient);
-                $message->loadFromArray($item);
+                $message->loadFromStdclass($item);
 
                 $baseList->items[] = $message;
             }
@@ -189,7 +195,7 @@ class Messages
         }
 
         $message = new Message();
-        $message->loadFromArray($body);
+        $message->loadFromStdclass($body);
 
         return $message;
     }

--- a/src/MessageBird/Resources/Conversation/Send.php
+++ b/src/MessageBird/Resources/Conversation/Send.php
@@ -23,7 +23,7 @@ class Send extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new SendMessageResult());
+        $this->object = new SendMessageResult();
         $this->setResourceName(self::RESOURCE_NAME);
     }
 

--- a/src/MessageBird/Resources/Conversation/Webhooks.php
+++ b/src/MessageBird/Resources/Conversation/Webhooks.php
@@ -14,7 +14,7 @@ class Webhooks extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new Webhook());
+        $this->object = new Webhook();
         $this->setResourceName(self::RESOURCE_NAME);
     }
 }

--- a/src/MessageBird/Resources/EmailMessage.php
+++ b/src/MessageBird/Resources/EmailMessage.php
@@ -14,7 +14,7 @@ class EmailMessage extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\EmailMessage());
+        $this->object = new Objects\EmailMessage();
         $this->setResourceName('verify/messages/email');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Groups.php
+++ b/src/MessageBird/Resources/Groups.php
@@ -14,10 +14,17 @@ use MessageBird\Objects;
  */
 class Groups extends Base
 {
+    /**
+     * @var Contacts
+     */
+    private $contactsObject;
+
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Group());
+        $this->object = new Objects\Group();
         $this->setResourceName('groups');
+
+        $this->contactsObject = new Contacts($httpClient);
 
         parent::__construct($httpClient);
     }
@@ -73,10 +80,9 @@ class Groups extends Base
         if ($id === null) {
             throw new InvalidArgumentException('No group id provided.');
         }
-        $contactResource = new Contacts($this->httpClient);
-        $contactResource->setResourceName($this->resourceName . '/' . $id . '/contacts');
 
-        return $contactResource->getList($parameters);
+        $this->contactsObject->setResourceName($this->resourceName . '/' . $id . '/contacts');
+        return $this->contactsObject->getList($parameters);
     }
 
     /**

--- a/src/MessageBird/Resources/Groups.php
+++ b/src/MessageBird/Resources/Groups.php
@@ -73,9 +73,10 @@ class Groups extends Base
         if ($id === null) {
             throw new InvalidArgumentException('No group id provided.');
         }
+        $contactResource = new Contacts($this->httpClient);
+        $contactResource->setResourceName($this->resourceName . '/' . $id . '/contacts');
 
-        $this->setResourceName($this->resourceName . '/' . $id . '/contacts');
-        return $this->getList($parameters);
+        return $contactResource->getList($parameters);
     }
 
     /**

--- a/src/MessageBird/Resources/Hlr.php
+++ b/src/MessageBird/Resources/Hlr.php
@@ -14,7 +14,7 @@ class Hlr extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Hlr());
+        $this->object = new Objects\Hlr();
         $this->setResourceName('hlr');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Lookup.php
+++ b/src/MessageBird/Resources/Lookup.php
@@ -19,7 +19,7 @@ class Lookup extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Lookup());
+        $this->object = new Objects\Lookup();
         $this->setResourceName('lookup');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/LookupHlr.php
+++ b/src/MessageBird/Resources/LookupHlr.php
@@ -19,7 +19,7 @@ class LookupHlr extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Hlr());
+        $this->object = new Objects\Hlr();
         $this->setResourceName('lookup');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Messages.php
+++ b/src/MessageBird/Resources/Messages.php
@@ -14,7 +14,7 @@ class Messages extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Message());
+        $this->object = new Objects\Message();
         $this->setResponseObject(new Objects\MessageResponse());
         $this->setResourceName('messages');
 

--- a/src/MessageBird/Resources/MmsMessages.php
+++ b/src/MessageBird/Resources/MmsMessages.php
@@ -14,7 +14,7 @@ class MmsMessages extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\MmsMessage());
+        $this->object = new Objects\MmsMessage();
         $this->setResourceName('mms');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/PartnerAccount/Accounts.php
+++ b/src/MessageBird/Resources/PartnerAccount/Accounts.php
@@ -22,7 +22,7 @@ class Accounts extends Base
     {
         parent::__construct($httpClient);
 
-        $this->setObject(new Account());
+        $this->object = new Account();
         $this->setResourceName(self::RESOURCE_NAME);
     }
 
@@ -69,11 +69,11 @@ class Accounts extends Base
             return $this->processRequest($body);
         }
 
-        $response = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+        $response = json_decode($body, false, 512, \JSON_THROW_ON_ERROR);
 
         $return = [];
         foreach ($response as &$singleResponse) {
-            $return[] = $this->getObject()->loadFromArray($singleResponse);
+            $return[] = $this->getObject()->loadFromStdclass($singleResponse);
         }
 
         return $return;

--- a/src/MessageBird/Resources/PhoneNumbers.php
+++ b/src/MessageBird/Resources/PhoneNumbers.php
@@ -19,7 +19,7 @@ class PhoneNumbers extends Base
 
     public function __construct(HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Number());
+        $this->object = new Objects\Number();
         $this->setResourceName('phone-numbers');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Verify.php
+++ b/src/MessageBird/Resources/Verify.php
@@ -18,7 +18,7 @@ class Verify extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Verify());
+        $this->object = new Objects\Verify();
         $this->setResourceName('verify');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Voice/Base.php
+++ b/src/MessageBird/Resources/Voice/Base.php
@@ -45,7 +45,7 @@ class Base extends \MessageBird\Resources\Base
 
             $baseList = new BaseList();
             if (property_exists($body, 'pagination')) {
-                $baseList->loadFromArray($body->pagination);
+                $baseList->loadFromStdclass($body->pagination);
             }
 
             $objectName = $this->object;
@@ -54,7 +54,7 @@ class Base extends \MessageBird\Resources\Base
                 /** @psalm-suppress UndefinedClass */
                 $itemObject = new $objectName($this->httpClient);
 
-                $message = $itemObject->loadFromArray($singleData);
+                $message = $itemObject->loadFromStdclass($singleData);
                 $baseList->items[] = $message;
             }
             return $baseList;
@@ -82,7 +82,7 @@ class Base extends \MessageBird\Resources\Base
         }
 
         if (empty($body->errors)) {
-            return $this->object->loadFromArray($body->data[0]);
+            return $this->object->loadFromStdclass($body->data[0]);
         }
 
         $responseError = new Common\ResponseError($body);

--- a/src/MessageBird/Resources/Voice/CallFlows.php
+++ b/src/MessageBird/Resources/Voice/CallFlows.php
@@ -14,7 +14,7 @@ class CallFlows extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Voice\CallFlow());
+        $this->object = new Objects\Voice\CallFlow();
         $this->setResourceName('call-flows');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Voice/Calls.php
+++ b/src/MessageBird/Resources/Voice/Calls.php
@@ -14,7 +14,7 @@ class Calls extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Voice\Call());
+        $this->object = new Objects\Voice\Call();
         $this->setResourceName('calls');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/Voice/Legs.php
+++ b/src/MessageBird/Resources/Voice/Legs.php
@@ -27,7 +27,7 @@ class Legs
     public function __construct(HttpClient $httpClient)
     {
         $this->httpClient = $httpClient;
-        $this->setObject(new Objects\Voice\Leg());
+        $this->object = new Objects\Voice\Leg();
     }
 
     public function getObject(): Objects\Voice\Leg
@@ -36,6 +36,8 @@ class Legs
     }
 
     /**
+     * @deprecated
+     * 
      * @param mixed $object
      */
     public function setObject($object): void
@@ -67,7 +69,7 @@ class Legs
             unset($body->data);
 
             $baseList = new Objects\BaseList();
-            $baseList->loadFromArray($body);
+            $baseList->loadFromStdclass($body);
 
             $objectName = $this->object;
 
@@ -75,7 +77,7 @@ class Legs
                 /** @psalm-suppress UndefinedClass */
                 $object = new $objectName($this->httpClient);
 
-                $itemObject = $object->loadFromArray($item);
+                $itemObject = $object->loadFromStdclass($item);
                 $baseList->items[] = $itemObject;
             }
             return $baseList;
@@ -103,7 +105,7 @@ class Legs
         }
 
         if (empty($body->errors)) {
-            return $this->object->loadFromArray($body->data[0]);
+            return $this->object->loadFromStdclass($body->data[0]);
         }
 
         $responseError = new Common\ResponseError($body);

--- a/src/MessageBird/Resources/Voice/Recordings.php
+++ b/src/MessageBird/Resources/Voice/Recordings.php
@@ -27,7 +27,7 @@ class Recordings
     public function __construct(HttpClient $httpClient)
     {
         $this->httpClient = $httpClient;
-        $this->setObject(new Objects\Voice\Recording());
+        $this->object = new Objects\Voice\Recording();
     }
 
     public function getObject(): Objects\Voice\Recording
@@ -36,6 +36,8 @@ class Recordings
     }
 
     /**
+     * @deprecated
+     * 
      * @param mixed $object
      */
     public function setObject($object): void
@@ -64,7 +66,7 @@ class Recordings
             unset($body->data);
 
             $baseList = new Objects\BaseList();
-            $baseList->loadFromArray($body);
+            $baseList->loadFromStdclass($body);
 
             $objectName = $this->object;
 
@@ -72,7 +74,7 @@ class Recordings
                 /** @psalm-suppress UndefinedClass */
                 $object = new $objectName($this->httpClient);
 
-                $itemObject = $object->loadFromArray($item);
+                $itemObject = $object->loadFromStdclass($item);
                 $baseList->items[] = $itemObject;
             }
             return $baseList;
@@ -100,7 +102,7 @@ class Recordings
         }
 
         if (empty($body->errors)) {
-            return $this->object->loadFromArray($body->data[0]);
+            return $this->object->loadFromStdclass($body->data[0]);
         }
 
         $responseError = new Common\ResponseError($body);

--- a/src/MessageBird/Resources/Voice/Transcriptions.php
+++ b/src/MessageBird/Resources/Voice/Transcriptions.php
@@ -27,7 +27,7 @@ class Transcriptions
     public function __construct(HttpClient $httpClient)
     {
         $this->httpClient = $httpClient;
-        $this->setObject(new Objects\Voice\Transcription());
+        $this->object = new Objects\Voice\Transcription();
     }
 
     public function getObject(): Objects\Voice\Transcription
@@ -36,6 +36,8 @@ class Transcriptions
     }
 
     /**
+     * @deprecated
+     * 
      * @param mixed $object
      */
     public function setObject($object): void
@@ -80,7 +82,7 @@ class Transcriptions
         }
 
         if (empty($body->errors)) {
-            return $this->object->loadFromArray($body->data[0]);
+            return $this->object->loadFromStdclass($body->data[0]);
         }
 
         $responseError = new Common\ResponseError($body);
@@ -111,7 +113,7 @@ class Transcriptions
             unset($body->data);
 
             $baseList = new Objects\BaseList();
-            $baseList->loadFromArray($body);
+            $baseList->loadFromStdclass($body);
 
             $objectName = $this->object;
 
@@ -119,7 +121,7 @@ class Transcriptions
                 /** @psalm-suppress UndefinedClass */
                 $object = new $objectName($this->httpClient);
 
-                $itemObject = $object->loadFromArray($item);
+                $itemObject = $object->loadFromStdclass($item);
                 $baseList->items[] = $itemObject;
             }
             return $baseList;

--- a/src/MessageBird/Resources/Voice/Webhooks.php
+++ b/src/MessageBird/Resources/Voice/Webhooks.php
@@ -14,7 +14,7 @@ class Webhooks extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\Voice\Webhook());
+        $this->object = new Objects\Voice\Webhook();
         $this->setResourceName('webhooks');
 
         parent::__construct($httpClient);

--- a/src/MessageBird/Resources/VoiceMessage.php
+++ b/src/MessageBird/Resources/VoiceMessage.php
@@ -14,7 +14,7 @@ class VoiceMessage extends Base
 {
     public function __construct(Common\HttpClient $httpClient)
     {
-        $this->setObject(new Objects\VoiceMessage());
+        $this->object = new Objects\VoiceMessage();
         $this->setResourceName('voicemessages');
 
         parent::__construct($httpClient);

--- a/tests/Integration/Contacts/ContactTest.php
+++ b/tests/Integration/Contacts/ContactTest.php
@@ -6,6 +6,7 @@ use MessageBird\Common\HttpClient;
 use MessageBird\Exceptions\ServerException;
 use MessageBird\Objects\BaseList;
 use MessageBird\Objects\Contact;
+use MessageBird\Objects\Group;
 use MessageBird\Objects\Message;
 use Tests\Integration\BaseTest;
 
@@ -118,7 +119,7 @@ class ContactTest extends BaseTest
             'last' => '',
         ];
         $groupList->items = [
-            (object)[
+            (new Group())->loadFromArray([
                 'id' => 'contact_id',
                 'href' => '',
                 'name' => 'GroupName',
@@ -128,7 +129,7 @@ class ContactTest extends BaseTest
                 ],
                 'createdDatetime' => '',
                 'updatedDatetime' => '',
-            ],
+            ]),
         ];
 
         self::assertEquals($groupList, $resultingGroupList);

--- a/tests/Integration/Contacts/ContactTest.php
+++ b/tests/Integration/Contacts/ContactTest.php
@@ -119,17 +119,19 @@ class ContactTest extends BaseTest
             'last' => '',
         ];
         $groupList->items = [
-            (new Group())->loadFromArray([
-                'id' => 'contact_id',
-                'href' => '',
-                'name' => 'GroupName',
-                'contacts' => (object)[
-                    'totalCount' => 1,
+            (new Group())->loadFromStdclass(
+                (object) [
+                    'id' => 'contact_id',
                     'href' => '',
-                ],
-                'createdDatetime' => '',
-                'updatedDatetime' => '',
-            ]),
+                    'name' => 'GroupName',
+                    'contacts' => (object)[
+                        'totalCount' => 1,
+                        'href' => '',
+                    ],
+                    'createdDatetime' => '',
+                    'updatedDatetime' => '',
+                ]
+            ),
         ];
 
         self::assertEquals($groupList, $resultingGroupList);

--- a/tests/Integration/Conversation/ConversationContentTest.php
+++ b/tests/Integration/Conversation/ConversationContentTest.php
@@ -28,7 +28,7 @@ class ConversationContentTest extends BaseTest
     private function messageFromJson(string $json): Message
     {
         $message = new Message();
-        $message->loadFromArray(
+        $message->loadFromStdclass(
             json_decode($json)
         );
 


### PR DESCRIPTION
I fixed the Group::loadFromArray method and added return type to other objects.