### PR TITLE
Add additional properties to Recipient object

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions:^4.6
+        uses: docker://vimeo/psalm-github-actions:stable

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:4.18.1

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions:4.18.1
+        uses: docker://vimeo/psalm-github-actions:^4.6

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions:stable
+        uses: docker://vimeo/psalm-github-actions:v4

--- a/src/MessageBird/Objects/Recipient.php
+++ b/src/MessageBird/Objects/Recipient.php
@@ -29,9 +29,85 @@ class Recipient extends Base
     public $status;
 
     /**
-     * The datum time of the last status in RFC3339 format (Y-m-d\TH:i:sP)
+     * The date and time of the last status in RFC3339 format (Y-m-d\TH:i:sP)
      *
      * @var string
      */
     public $statusDatetime;
+
+
+    /**
+     * The details about the status message. More details can be found here:
+     * https://developers.messagebird.com/api/sms-messaging/#sms-statuses
+     *
+     * @var string
+     */
+    public $statusReason;
+
+    /**
+     * Extra error code that describes the failure in more detail (optional, 
+     * null if not available)
+     *
+     * @var string
+     */
+    public $statusErrorCode;
+
+    /**
+     * The name of the recipient’s original country, based on MSISDN.
+     *
+     * @var string
+     */
+    public $recipientCountry;
+
+    /**
+     * The prefix code for the recipient’s original country, based on MSISDN.
+     *
+     * @var int
+     */
+    public $recipientCountryPrefix;
+
+    /**
+     * The name of the operator of the recipient. Identified by MCCMNC 
+     * of the message.
+     *
+     * @var string
+     */
+    public $recipientOperator;
+
+    /**
+     * The code of the operator of the message sender. 
+     * It could have null value if the message isn’t delivered yet.
+     *
+     * @var string
+     */
+    public $mccmnc;
+
+    /**
+     * The MCC (Mobile Country Code) part of MCCMNC.
+     *
+     * @var string
+     */
+    public $mcc;
+
+    /**
+     * The MNC (Mobile Network Code) part of MCCMNC.
+     *
+     * @var string
+     */
+    public $mnc;
+    
+    /**
+     * The length of the message in characters. Depends on the 
+     * message datacoding.
+     *
+     * @var int
+     */
+    public $messageLength;
+
+    /**
+     * The count of total messages send. Personalisation not taken in account.
+     *
+     * @var int
+     */
+    public $messagePartCount;
 }

--- a/tests/Integration/Messages/MessagesTest.php
+++ b/tests/Integration/Messages/MessagesTest.php
@@ -170,7 +170,21 @@ class MessagesTest extends BaseTest
                       {
                         "recipient":31612345678,
                         "status":"sent",
-                        "statusDatetime":"2015-07-03T07:55:31+00:00"
+                        "statusDatetime":"2015-07-03T07:55:31+00:00",
+                        "statusReason":"successfully delivered",
+                        "statusErrorCode":null,
+                        "recipientCountry":"Netherlands",
+                        "recipientCountryPrefix":31,
+                        "recipientOperator":"KPN",
+                        "mccmnc":"20408",
+                        "mcc":"204",
+                        "mnc":"08",
+                        "messageLength":22,
+                        "messagePartCount":1,
+                        "price":{
+                            "amount":0.075,
+                            "currency":"EUR"
+                        }
                       }
                     ]
                   },
@@ -206,5 +220,15 @@ class MessagesTest extends BaseTest
         self::assertSame(31612345678, $messageResponse->recipients->items[0]->recipient);
         self::assertSame('sent', $messageResponse->recipients->items[0]->status);
         self::assertSame('2015-07-03T07:55:31+00:00', $messageResponse->recipients->items[0]->statusDatetime);
+        self::assertSame('successfully delivered', $messageResponse->recipients->items[0]->statusReason);
+        self::assertSame(null, $messageResponse->recipients->items[0]->statusErrorCode);
+        self::assertSame('Netherlands', $messageResponse->recipients->items[0]->recipientCountry);
+        self::assertSame(31, $messageResponse->recipients->items[0]->recipientCountryPrefix);
+        self::assertSame('KPN', $messageResponse->recipients->items[0]->recipientOperator);
+        self::assertSame('20408', $messageResponse->recipients->items[0]->mccmnc);
+        self::assertSame('204', $messageResponse->recipients->items[0]->mcc);
+        self::assertSame('08', $messageResponse->recipients->items[0]->mnc);
+        self::assertSame(22, $messageResponse->recipients->items[0]->messageLength);
+        self::assertSame(1, $messageResponse->recipients->items[0]->messagePartCount);           
     }
 }


### PR DESCRIPTION
The REST API returns attributes not included in the `Recipient` object. This PR
adds additional attributes with one exception; pricing information.