### PR TITLE
Pin psalm version in composer and github action

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:v4

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Psalm – Static Analysis for PHP
-        uses: docker://vimeo/psalm-github-actions:v4
+        uses: docker://vimeo/psalm-github-actions:4.18.1

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",
-        "vimeo/psalm": "^4.6"
+        "vimeo/psalm": "4.18.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Pin psalm to 4.18.1

On every pull request we run psalm using a GitHub action. The GitHub action
was using the `latest` version of psalm. On this [1] PR that resulted in psalm
passing locally but breaking in the PR.

This pins the version of psalm in composer and in the GitHub action to 4.18.1.

[1] https://github.com/messagebird/php-rest-api/pull/186