### PR TITLE
Correct typing in phpdocs and fix getCustomDetails()

### DIFF
--- a/src/MessageBird/Objects/Contact.php
+++ b/src/MessageBird/Objects/Contact.php
@@ -61,7 +61,7 @@ class Contact extends Base
     /**
      * Custom fields of the contact.
      *
-     * @var array
+     * @var stdClass
      */
     protected $customDetails = [];
     /**
@@ -88,7 +88,7 @@ class Contact extends Base
     /**
      * The date and time of the updated of the contact in RFC3339 format (Y-m-d\TH:i:sP)
      *
-     * @var string
+     * @var string|null
      */
     protected $updatedDatetime;
 
@@ -122,7 +122,7 @@ class Contact extends Base
         return $this->updatedDatetime;
     }
 
-    public function getCustomDetails(): array
+    public function getCustomDetails(): stdClass
     {
         return $this->customDetails;
     }

--- a/src/MessageBird/Objects/Conversation/Contact.php
+++ b/src/MessageBird/Objects/Conversation/Contact.php
@@ -28,7 +28,7 @@ class Contact extends Base
     /**
      * The MSISDN/phone number of this contact.
      *
-     * @var string
+     * @var int|null
      */
     public $msisdn;
 

--- a/src/MessageBird/Objects/Conversation/Conversation.php
+++ b/src/MessageBird/Objects/Conversation/Conversation.php
@@ -29,7 +29,7 @@ class Conversation extends Base
     /**
      * The URL of this conversation object.
      *
-     * @var string
+     * @var string|null
      */
     public $href;
 

--- a/src/MessageBird/Objects/Conversation/Message.php
+++ b/src/MessageBird/Objects/Conversation/Message.php
@@ -44,7 +44,7 @@ class Message extends Base implements JsonSerializable
      * outbound messages sent through the API or 'received' (mobile-originated)
      * for inbound messages from the contact.
      *
-     * @var string
+     * @var string|null
      */
     public $direction;
 
@@ -59,7 +59,7 @@ class Message extends Base implements JsonSerializable
 
     /**
      * Type of this message's content. Possible values: "text", "image",
-     * "audio", "video", "file", "location".
+     * "audio", "video", "file", "location", "hsm", "interactive", "email".
      *
      * @var string
      */

--- a/src/MessageBird/Objects/Conversation/MessageReference.php
+++ b/src/MessageBird/Objects/Conversation/MessageReference.php
@@ -25,8 +25,7 @@ class MessageReference extends Base
     public $totalCount;
     
     /**
-     *
-     * @var string
+     * @var string|null
      */
     public $lastMessageId;
 }

--- a/src/MessageBird/Objects/Conversation/Webhook.php
+++ b/src/MessageBird/Objects/Conversation/Webhook.php
@@ -30,7 +30,7 @@ class Webhook extends Base implements JsonSerializable
     /**
      * The URL of this webhook object.
      *
-     * @var string
+     * @var string|null
      */
     public $href;
 


### PR DESCRIPTION
These are the ones I've caught when working with the library. There may be more.

Mostly just updates to phpdocs. There's one change of the return type: `getCustomDetails()` always crashed previously because it was returning `stdClass`, but declared an `array`.