### PR TITLE
Use MessageReponse mapper instead of Message when calling list endpoint

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -13,7 +13,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Psalm – Static Analysis for PHP
         uses: docker://vimeo/psalm-github-actions:4.18.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1' ]
-        stability: [ prefer-lowest, prefer-stable ]
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
+        stability: [ prefer-stable ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/MessageBird/Resources/Base.php
+++ b/src/MessageBird/Resources/Base.php
@@ -186,10 +186,14 @@ class Base
 
             foreach ($items as $item) {
                 /** @psalm-suppress UndefinedClass */
-                $object = new $objectName($this->httpClient);
+                if ($this->responseObject) {
+                    $baseList->items[] =  $this->responseObject->loadFromStdclass($item);
+                } else {
+                    $object = new $objectName($this->httpClient);
 
-                $message = $object->loadFromArray($item);
-                $baseList->items[] = $message;
+                    $message = $object->loadFromArray($item);
+                    $baseList->items[] = $message;
+                }
             }
 
             return $baseList;

--- a/src/MessageBird/Resources/Base.php
+++ b/src/MessageBird/Resources/Base.php
@@ -186,7 +186,8 @@ class Base
 
             foreach ($items as $item) {
                 if ($this->responseObject) {
-                    $baseList->items[] =  $this->responseObject->loadFromStdclass($item);
+                    $responseObject = clone $this->responseObject;
+                    $baseList->items[] =  $responseObject->loadFromStdclass($item);
                 } else {
                     /** @psalm-suppress UndefinedClass */
                     $object = new $objectName($this->httpClient);

--- a/src/MessageBird/Resources/Base.php
+++ b/src/MessageBird/Resources/Base.php
@@ -185,10 +185,10 @@ class Base
             }
 
             foreach ($items as $item) {
-                /** @psalm-suppress UndefinedClass */
                 if ($this->responseObject) {
                     $baseList->items[] =  $this->responseObject->loadFromStdclass($item);
                 } else {
+                    /** @psalm-suppress UndefinedClass */
                     $object = new $objectName($this->httpClient);
 
                     $message = $object->loadFromArray($item);

--- a/tests/Integration/Contacts/ContactTest.php
+++ b/tests/Integration/Contacts/ContactTest.php
@@ -7,7 +7,6 @@ use MessageBird\Exceptions\ServerException;
 use MessageBird\Objects\BaseList;
 use MessageBird\Objects\Contact;
 use MessageBird\Objects\Group;
-use MessageBird\Objects\Message;
 use MessageBird\Objects\MessageResponse;
 
 use Tests\Integration\BaseTest;

--- a/tests/Integration/Contacts/ContactTest.php
+++ b/tests/Integration/Contacts/ContactTest.php
@@ -8,6 +8,8 @@ use MessageBird\Objects\BaseList;
 use MessageBird\Objects\Contact;
 use MessageBird\Objects\Group;
 use MessageBird\Objects\Message;
+use MessageBird\Objects\MessageResponse;
+
 use Tests\Integration\BaseTest;
 
 class ContactTest extends BaseTest
@@ -155,7 +157,7 @@ class ContactTest extends BaseTest
         $messages = $this->client->contacts->getMessages("contact_id");
 
         foreach ($messages->items as $message) {
-            self::assertInstanceOf(Message::class, $message);
+            self::assertInstanceOf(MessageResponse::class, $message);
         }
     }
 }

--- a/tests/Integration/Messages/MessagesTest.php
+++ b/tests/Integration/Messages/MessagesTest.php
@@ -119,8 +119,8 @@ class MessagesTest extends BaseTest
         self::assertSame('7d8451f8', $messageList->items[0]->id);
         self::assertSame('https://rest.messagebird.com/messages/7d8451f8', $messageList->items[0]->href);
 
-        self::assertSame('7d8451f8', $messageList->items[1]->id);
-        self::assertSame('https://rest.messagebird.com/messages/7d8451f8', $messageList->items[1]->href);
+        self::assertSame('7d8451f9', $messageList->items[1]->id);
+        self::assertSame('https://rest.messagebird.com/messages/7d8451f9', $messageList->items[1]->href);
 
     }
 

--- a/tests/Integration/Messages/MessagesTest.php
+++ b/tests/Integration/Messages/MessagesTest.php
@@ -103,66 +103,7 @@ class MessagesTest extends BaseTest
         $this->mockClient->expects(self::atLeastOnce())->method('performHttpRequest')->willReturn([
             200,
             '',
-            '{
-  "offset": 0,
-  "limit": 10,
-  "count": 10,
-  "totalCount": 16,
-  "links": {
-    "first": "https://rest.messagebird.com/messages/?offset=0&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
-    "previous": null,
-    "next": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
-    "last": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00"
-  },
-  "items": [
-    {
-      "id": "7d8451f8",
-      "href": "https://rest.messagebird.com/messages/7d8451f8",
-      "direction": "mt",
-      "type": "sms",
-      "originator": "+31612345678",
-      "body": "Hi there",
-      "reference": null,
-      "validity": null,
-      "gateway": 10,
-      "typeDetails": {
-        "verify": true
-      },
-      "datacoding": "plain",
-      "mclass": 1,
-      "scheduledDatetime": null,
-      "createdDatetime": "2022-10-12T18:46:22+00:00",
-      "recipients": {
-        "totalCount": 1,
-        "totalSentCount": 1,
-        "totalDeliveredCount": 1,
-        "totalDeliveryFailedCount": 0,
-        "items": [
-          {
-            "recipient": 31612345678,
-            "originator": null,
-            "status": "delivered",
-            "statusDatetime": "2022-10-12T18:46:24+00:00",
-            "recipientCountry": "Netherlands",
-            "recipientCountryPrefix": 31,
-            "recipientOperator": "KPN",
-            "messageLength": 20,
-            "statusErrorCode": null,
-            "statusReason": "successfully delivered",
-            "price": {
-              "amount": 0.076,
-              "currency": "EUR"
-            },
-            "mccmnc": "20408",
-            "mcc": "204",
-            "mnc": "08",
-            "messagePartCount": 1
-          }
-        ]
-      }
-    }
-  ]
-}',
+            file_get_contents(__DIR__ . '/get-list-response.json')
         ]);
 
         $this->mockClient->expects(self::once())->method('performHttpRequest')->with(
@@ -177,6 +118,9 @@ class MessagesTest extends BaseTest
 
         self::assertSame('7d8451f8', $messageList->items[0]->id);
         self::assertSame('https://rest.messagebird.com/messages/7d8451f8', $messageList->items[0]->href);
+
+        self::assertSame('7d8451f8', $messageList->items[1]->id);
+        self::assertSame('https://rest.messagebird.com/messages/7d8451f8', $messageList->items[1]->href);
 
     }
 

--- a/tests/Integration/Messages/MessagesTest.php
+++ b/tests/Integration/Messages/MessagesTest.php
@@ -100,14 +100,84 @@ class MessagesTest extends BaseTest
 
     public function testListMessage(): void
     {
-        $this->expectException(ServerException::class);
+        $this->mockClient->expects(self::atLeastOnce())->method('performHttpRequest')->willReturn([
+            200,
+            '',
+            '{
+  "offset": 0,
+  "limit": 10,
+  "count": 10,
+  "totalCount": 16,
+  "links": {
+    "first": "https://rest.messagebird.com/messages/?offset=0&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
+    "previous": null,
+    "next": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
+    "last": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00"
+  },
+  "items": [
+    {
+      "id": "7d8451f8",
+      "href": "https://rest.messagebird.com/messages/7d8451f8",
+      "direction": "mt",
+      "type": "sms",
+      "originator": "+31612345678",
+      "body": "Hi there",
+      "reference": null,
+      "validity": null,
+      "gateway": 10,
+      "typeDetails": {
+        "verify": true
+      },
+      "datacoding": "plain",
+      "mclass": 1,
+      "scheduledDatetime": null,
+      "createdDatetime": "2022-10-12T18:46:22+00:00",
+      "recipients": {
+        "totalCount": 1,
+        "totalSentCount": 1,
+        "totalDeliveredCount": 1,
+        "totalDeliveryFailedCount": 0,
+        "items": [
+          {
+            "recipient": 31612345678,
+            "originator": null,
+            "status": "delivered",
+            "statusDatetime": "2022-10-12T18:46:24+00:00",
+            "recipientCountry": "Netherlands",
+            "recipientCountryPrefix": 31,
+            "recipientOperator": "KPN",
+            "messageLength": 20,
+            "statusErrorCode": null,
+            "statusReason": "successfully delivered",
+            "price": {
+              "amount": 0.076,
+              "currency": "EUR"
+            },
+            "mccmnc": "20408",
+            "mcc": "204",
+            "mnc": "08",
+            "messagePartCount": 1
+          }
+        ]
+      }
+    }
+  ]
+}',
+        ]);
+
         $this->mockClient->expects(self::once())->method('performHttpRequest')->with(
             "GET",
             'messages',
             ['offset' => 100, 'limit' => 30],
             null
         );
-        $this->client->messages->getList(['offset' => 100, 'limit' => 30]);
+
+
+        $messageList = $this->client->messages->getList(['offset' => 100, 'limit' => 30]);
+
+        self::assertSame('7d8451f8', $messageList->items[0]->id);
+        self::assertSame('https://rest.messagebird.com/messages/7d8451f8', $messageList->items[0]->href);
+
     }
 
     public function testReadMessage(): void

--- a/tests/Integration/Messages/get-list-response.json
+++ b/tests/Integration/Messages/get-list-response.json
@@ -1,0 +1,116 @@
+{
+    "offset": 0,
+    "limit": 10,
+    "count": 10,
+    "totalCount": 16,
+    "links":
+    {
+        "first": "https://rest.messagebird.com/messages/?offset=0&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
+        "previous": null,
+        "next": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00",
+        "last": "https://rest.messagebird.com/messages/?offset=10&limit=10&recipient=31653474496&from=2021-03-16T00%3A00%3A00%2B00%3A00"
+    },
+    "items":
+    [
+        {
+            "id": "7d8451f8",
+            "href": "https://rest.messagebird.com/messages/7d8451f8",
+            "direction": "mt",
+            "type": "sms",
+            "originator": "+31612345678",
+            "body": "Hi there",
+            "reference": null,
+            "validity": null,
+            "gateway": 10,
+            "typeDetails":
+            {
+                "verify": true
+            },
+            "datacoding": "plain",
+            "mclass": 1,
+            "scheduledDatetime": null,
+            "createdDatetime": "2022-10-12T18:46:22+00:00",
+            "recipients":
+            {
+                "totalCount": 1,
+                "totalSentCount": 1,
+                "totalDeliveredCount": 1,
+                "totalDeliveryFailedCount": 0,
+                "items":
+                [
+                    {
+                        "recipient": 31612345678,
+                        "originator": null,
+                        "status": "delivered",
+                        "statusDatetime": "2022-10-12T18:46:24+00:00",
+                        "recipientCountry": "Netherlands",
+                        "recipientCountryPrefix": 31,
+                        "recipientOperator": "KPN",
+                        "messageLength": 20,
+                        "statusErrorCode": null,
+                        "statusReason": "successfully delivered",
+                        "price":
+                        {
+                            "amount": 0.076,
+                            "currency": "EUR"
+                        },
+                        "mccmnc": "20408",
+                        "mcc": "204",
+                        "mnc": "08",
+                        "messagePartCount": 1
+                    }
+                ]
+            }
+        },
+        {
+            "id": "7d8451f8",
+            "href": "https://rest.messagebird.com/messages/7d8451f8",
+            "direction": "mt",
+            "type": "sms",
+            "originator": "+31612345678",
+            "body": "Hi there",
+            "reference": null,
+            "validity": null,
+            "gateway": 10,
+            "typeDetails":
+            {
+                "verify": true
+            },
+            "datacoding": "plain",
+            "mclass": 1,
+            "scheduledDatetime": null,
+            "createdDatetime": "2022-10-12T18:46:22+00:00",
+            "recipients":
+            {
+                "totalCount": 1,
+                "totalSentCount": 1,
+                "totalDeliveredCount": 1,
+                "totalDeliveryFailedCount": 0,
+                "items":
+                [
+                    {
+                        "recipient": 31612345678,
+                        "originator": null,
+                        "status": "delivered",
+                        "statusDatetime": "2022-10-12T18:46:24+00:00",
+                        "recipientCountry": "Netherlands",
+                        "recipientCountryPrefix": 31,
+                        "recipientOperator": "KPN",
+                        "messageLength": 20,
+                        "statusErrorCode": null,
+                        "statusReason": "successfully delivered",
+                        "price":
+                        {
+                            "amount": 0.076,
+                            "currency": "EUR"
+                        },
+                        "mccmnc": "20408",
+                        "mcc": "204",
+                        "mnc": "08",
+                        "messagePartCount": 1
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/Integration/Messages/get-list-response.json
+++ b/tests/Integration/Messages/get-list-response.json
@@ -63,8 +63,8 @@
             }
         },
         {
-            "id": "7d8451f8",
-            "href": "https://rest.messagebird.com/messages/7d8451f8",
+            "id": "7d8451f9",
+            "href": "https://rest.messagebird.com/messages/7d8451f9",
             "direction": "mt",
             "type": "sms",
             "originator": "+31612345678",


### PR DESCRIPTION
The Message mapper is missing the `id` and `href` properties since that mapper is used to map requests. We were still using the Message mapper in the list endpoint which resulted in those properties being removed from the response.