### PR TITLE
Allow PHP 8.2 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "source": "https://github.com/messagebird/php-rest-api"
     },
     "require": {
-        "php": ">=7.3|~8.0.0|~8.1.0",
+        "php": ">=7.3|~8.0.0|~8.1.0|~8.2.0",
         "ext-curl": "*",
         "ext-json": "*",
         "firebase/php-jwt": "^5.5.1|^6.2"


### PR DESCRIPTION
PHP 8.2 is released on 8 December 2022

https://php.watch/news/2022/12/php8.2-released