### PR TITLE
Add `shortenUrls` property to Message

### DIFF
--- a/src/MessageBird/Objects/Message.php
+++ b/src/MessageBird/Objects/Message.php
@@ -116,6 +116,12 @@ class Message extends Base
      */
     public $reportUrl;
     /**
+     * Shorten all the URLs present in the message body
+     *
+     * @var bool
+     */
+    public $shortenUrls;
+    /**
      * The date and time of the creation of the message in RFC3339 format (Y-m-d\TH:i:sP)
      * @var string
      */


### PR DESCRIPTION
Add support for `shortenUrls` URL parameter when sending out a message.