### PR TITLE
Request signature validation fixes

### DIFF
--- a/src/MessageBird/RequestValidator.php
+++ b/src/MessageBird/RequestValidator.php
@@ -187,7 +187,7 @@ class RequestValidator
      */
     public function validateRequestFromGlobals()
     {
-        $signature = $_SERVER['MessageBird-Signature-JWT'] ?? null;
+        $signature = $_SERVER['MessageBird-Signature-JWT'] ?? '';
         $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") .
             "://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
         $body = file_get_contents('php://input');

--- a/src/MessageBird/RequestValidator.php
+++ b/src/MessageBird/RequestValidator.php
@@ -188,7 +188,8 @@ class RequestValidator
     public function validateRequestFromGlobals()
     {
         $signature = $_SERVER['MessageBird-Signature-JWT'] ?? null;
-        $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+        $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") .
+            "://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
         $body = file_get_contents('php://input');
 
         return $this->validateSignature($signature, $url, $body);

--- a/src/MessageBird/RequestValidator.php
+++ b/src/MessageBird/RequestValidator.php
@@ -187,7 +187,7 @@ class RequestValidator
      */
     public function validateRequestFromGlobals()
     {
-        $signature = $_SERVER['MessageBird-Signature-JWT'] ?? '';
+        $signature = $_SERVER['HTTP_MESSAGEBIRD_SIGNATURE_JWT'] ?? ($_SERVER['MessageBird-Signature-JWT'] ?? '');
         $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") .
             "://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
         $body = file_get_contents('php://input');


### PR DESCRIPTION
- Passing null when the header is missing causes a TypeError, as the signature must be a string.
- `$_SERVER` params were being accessed using undefined constants auto-converted to strings. Fix to use regular strings.
- HTTP headers are [usually keyed with `HTTP_` prefix](https://www.php.net/manual/en/reserved.variables.server.php), and using all uppercase characters and underscores. The existing check for simply `MessageBird-Signature-JWT` did not pick up the header when using Apache. Maybe that works on other web servers, so I've left it as a fallback.